### PR TITLE
Allow semi-permanent data directories to be set in config

### DIFF
--- a/rre-core/pom.xml
+++ b/rre-core/pom.xml
@@ -22,6 +22,11 @@
             <version>1.0</version>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.10</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/rre-core/src/main/java/io/sease/rre/core/Engine.java
+++ b/rre-core/src/main/java/io/sease/rre/core/Engine.java
@@ -78,6 +78,8 @@ public class Engine {
      * @param fields                   the fields to retrieve with each result.
      * @param exclude                  a list of folders to exclude when scanning the configuration folders.
      * @param include                  a list of folders to include from the configuration folders.
+     * @param checksumFilepath         the path to the file used to store the configuration checksums.
+     * @param persistenceConfiguration the persistence framework configuration.
      */
     public Engine(
             final SearchPlatform platform,
@@ -371,7 +373,8 @@ public class Engine {
                         return metric;
                     } catch (final Exception exception) {
                         throw new IllegalArgumentException(exception);
-                    }})
+                    }
+                })
                 .collect(toList());
     }
 

--- a/rre-core/src/main/java/io/sease/rre/core/FileUpdateChecker.java
+++ b/rre-core/src/main/java/io/sease/rre/core/FileUpdateChecker.java
@@ -8,6 +8,11 @@ import java.io.*;
 import java.nio.file.Files;
 import java.util.*;
 
+/**
+ * Manager class to track updates to configuration files.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
 public class FileUpdateChecker {
 
     private final static Logger LOGGER = LogManager.getLogger(FileUpdateChecker.class);
@@ -15,11 +20,28 @@ public class FileUpdateChecker {
     private final File checksumFile;
     private final Map<String, String> checksums;
 
+    /**
+     * Initialise the class with a checksum file. The checksums are read
+     * immediately - if the file does not exist, it will be created, otherwise
+     * the checksums will be read from the file.
+     *
+     * @param checksumFilepath the path to the checksum file in use. Set in
+     *                         config in the pom.xml.
+     * @throws IOException if the file exists and cannot be read.
+     */
     public FileUpdateChecker(String checksumFilepath) throws IOException {
         this.checksumFile = new File(checksumFilepath);
         checksums = readChecksums();
     }
 
+    /**
+     * Check whether a directory has changed since its checksum was written.
+     *
+     * @param directoryPath the path to the directory.
+     * @return {@code true} if the directory's checksum does not match the
+     * stored checksum.
+     * @throws IOException if the directory cannot be read.
+     */
     public boolean directoryHasChanged(String directoryPath) throws IOException {
         boolean ret = true;
 
@@ -57,6 +79,11 @@ public class FileUpdateChecker {
         return sums;
     }
 
+    /**
+     * Write the current checksums to the checksum file.
+     *
+     * @throws IOException if the file cannot be written.
+     */
     public void writeChecksums() throws IOException {
         if (checksums == null) {
             LOGGER.info("Skipping writeChecksums() - no checksums to write");
@@ -68,6 +95,20 @@ public class FileUpdateChecker {
         }
     }
 
+    /**
+     * Create a hash for the given directory, including all files and
+     * directories contained inside, optionally including or excluding
+     * hidden files.
+     * <p>
+     * Code taken from this Stackoverflow answer: https://stackoverflow.com/a/46899517
+     *
+     * @param directoryPath      the path to the directory to be hashed.
+     * @param includeHiddenFiles should hidden files be included?
+     * @return a string containing the hash of the directory, including all of
+     * its files.
+     * @throws IOException if the directory or any of its files cannot be
+     *                     read.
+     */
     static String hashDirectory(String directoryPath, boolean includeHiddenFiles) throws IOException {
         File directory = new File(directoryPath);
 

--- a/rre-core/src/main/java/io/sease/rre/core/FileUpdateChecker.java
+++ b/rre-core/src/main/java/io/sease/rre/core/FileUpdateChecker.java
@@ -1,0 +1,105 @@
+package io.sease.rre.core;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.*;
+
+public class FileUpdateChecker {
+
+    private final static Logger LOGGER = LogManager.getLogger(FileUpdateChecker.class);
+
+    private final File checksumFile;
+    private final Map<String, String> checksums;
+
+    public FileUpdateChecker(String checksumFilepath) throws IOException {
+        this.checksumFile = new File(checksumFilepath);
+        checksums = readChecksums();
+    }
+
+    public boolean directoryHasChanged(String directoryPath) throws IOException {
+        boolean ret = true;
+
+        String dirHash = hashDirectory(directoryPath, true);
+        if (checksums.containsKey(directoryPath)) {
+            ret = !checksums.get(directoryPath).equals(dirHash);
+        }
+
+        checksums.put(directoryPath, dirHash);
+
+        return ret;
+    }
+
+    private Map<String, String> readChecksums() throws IOException {
+        Map<String, String> sums = new HashMap<>();
+
+        if (!checksumFile.exists()) {
+            LOGGER.warn("Checksum file " + checksumFile.getAbsolutePath() + " does not exist");
+        } else {
+            try (BufferedReader br = new BufferedReader(new FileReader(checksumFile))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    if (!line.trim().isEmpty()) {
+                        String[] parts = line.split(",");
+                        if (parts.length != 2) {
+                            LOGGER.warn("Could not read checksum line [" + line + "]");
+                        } else {
+                            sums.put(parts[0], parts[1]);
+                        }
+                    }
+                }
+            }
+        }
+
+        return sums;
+    }
+
+    public void writeChecksums() throws IOException {
+        if (checksums == null) {
+            LOGGER.info("Skipping writeChecksums() - no checksums to write");
+        } else {
+            try (PrintWriter pw = new PrintWriter(new BufferedWriter(new FileWriter(checksumFile)))) {
+                checksums.forEach((dir, sum) -> pw.println(dir + "," + sum));
+                pw.flush();
+            }
+        }
+    }
+
+    static String hashDirectory(String directoryPath, boolean includeHiddenFiles) throws IOException {
+        File directory = new File(directoryPath);
+
+        if (!directory.isDirectory()) {
+            throw new IllegalArgumentException("Not a directory");
+        }
+
+        Vector<FileInputStream> fileStreams = new Vector<>();
+        collectFiles(directory, fileStreams, includeHiddenFiles);
+
+        try (SequenceInputStream sequenceInputStream = new SequenceInputStream(fileStreams.elements())) {
+            return DigestUtils.md5Hex(sequenceInputStream);
+        }
+    }
+
+    private static void collectFiles(File directory,
+                                     List<FileInputStream> fileInputStreams,
+                                     boolean includeHiddenFiles) throws IOException {
+        File[] files = directory.listFiles();
+
+        if (files != null) {
+            Arrays.sort(files, Comparator.comparing(File::getName));
+
+            for (File file : files) {
+                if (includeHiddenFiles || !Files.isHidden(file.toPath())) {
+                    if (file.isDirectory()) {
+                        collectFiles(file, fileInputStreams, includeHiddenFiles);
+                    } else {
+                        fileInputStreams.add(new FileInputStream(file));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rre-core/src/test/java/io/sease/rre/core/FileUpdateCheckerTest.java
+++ b/rre-core/src/test/java/io/sease/rre/core/FileUpdateCheckerTest.java
@@ -1,0 +1,91 @@
+package io.sease.rre.core;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+public class FileUpdateCheckerTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void directoryHasChanged_returnsTrueWhenNoChecksumFile() throws Exception {
+        final String checksumFilepath = "noSuchFile";
+        final String directoryPath = tempFolder.getRoot().getPath();
+        FileUpdateChecker checker = new FileUpdateChecker(checksumFilepath);
+
+        assertTrue(checker.directoryHasChanged(directoryPath));
+    }
+
+    @Test
+    public void directoryHasChanged_returnsTrueForNewDirectory() throws Exception {
+        File checksumFile = tempFolder.newFile("checksums.csv");
+
+        initialiseChecksumFile(checksumFile, 1);
+        File newDir = tempFolder.newFolder();
+
+        FileUpdateChecker checker = new FileUpdateChecker(checksumFile.getAbsolutePath());
+
+        assertTrue(checker.directoryHasChanged(newDir.getAbsolutePath()));
+    }
+
+    @Test
+    public void directoryHasChanged_returnsTrueForNewFileInDirectory() throws Exception {
+        File checksumFile = tempFolder.newFile("checksums.csv");
+
+        Map<String, String> checksums = initialiseChecksumFile(checksumFile, 3);
+
+        String existingDirPath = checksums.keySet().iterator().next();
+        // Create a new file under the first temp directory
+        File tmpFile = new File(existingDirPath, "newFile.txt");
+        try (final PrintWriter pw = new PrintWriter(new FileWriter(tmpFile))) {
+            pw.println("Blah");
+        }
+
+        FileUpdateChecker checker = new FileUpdateChecker(checksumFile.getAbsolutePath());
+
+        assertTrue(checker.directoryHasChanged(existingDirPath));
+    }
+
+    @Test
+    public void directoryHasChanged_returnsFalseForSameDirectory() throws Exception {
+        File checksumFile = tempFolder.newFile("checksums.csv");
+
+        Map<String, String> checksums = initialiseChecksumFile(checksumFile, 3);
+        String existingDirPath = checksums.keySet().iterator().next();
+        FileUpdateChecker checker = new FileUpdateChecker(checksumFile.getAbsolutePath());
+
+        assertFalse(checker.directoryHasChanged(existingDirPath));
+    }
+
+    private Map<String, String> initialiseChecksumFile(File checksumFile, int testDirCount) throws IOException {
+        Map<String, String> checksums = new HashMap<>();
+        for (int i = 0; i < testDirCount; i ++) {
+            File testDir = tempFolder.newFolder();
+            // Create a dummy file with unique text, so all checksums are different
+            File tmpFile = new File(testDir, "tmp.txt");
+            try (final PrintWriter pw = new PrintWriter(new FileWriter(tmpFile))) {
+                pw.println("Test " + i);
+            }
+            String checksum = FileUpdateChecker.hashDirectory(testDir.getAbsolutePath(), false);
+            checksums.put(testDir.getAbsolutePath(), checksum);
+        }
+
+        try (final PrintWriter pw = new PrintWriter(new FileWriter(checksumFile))) {
+            checksums.forEach((k, v) -> pw.println(k + "," + v));
+        }
+
+        return checksums;
+    }
+}

--- a/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
@@ -100,8 +100,8 @@ public class RREvaluateMojo extends AbstractMojo {
                     fields.split(","),
                     exclude,
                     include,
-                    persistence,
-                    checksumFile);
+                    checksumFile,
+                    persistence);
 
             final Map<String, Object> configuration = new HashMap<>();
             configuration.put("path.home", "/tmp");

--- a/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
@@ -43,6 +43,15 @@ public class RREvaluateMojo extends AbstractMojo {
     @Parameter(name = "templates-folder", defaultValue = "${basedir}/src/etc/templates")
     private String templatesFolder;
 
+    @Parameter(name = "data-folder", defaultValue = "target/elasticsearch/data")
+    private String dataFolder;
+
+    @Parameter(name = "force-refresh", defaultValue = "true")
+    private boolean forceRefresh;
+
+    @Parameter(name = "checksum-file")
+    private String checksumFile;
+
     @Parameter(name = "metrics", defaultValue = "io.sease.rre.core.domain.metrics.impl.PrecisionAtOne,io.sease.rre.core.domain.metrics.impl.PrecisionAtTwo,io.sease.rre.core.domain.metrics.impl.PrecisionAtThree,io.sease.rre.core.domain.metrics.impl.PrecisionAtTen")
     private List<String> metrics;
 
@@ -88,12 +97,15 @@ public class RREvaluateMojo extends AbstractMojo {
                     metrics,
                     fields.split(","),
                     exclude,
-                    include);
+                    include,
+                    checksumFile);
 
             final Map<String, Object> configuration = new HashMap<>();
             configuration.put("path.home", "/tmp");
+            configuration.put("path.data", dataFolder);
             configuration.put("network.host", port);
             configuration.put("plugins", plugins);
+            configuration.put("forceRefresh", forceRefresh);
 
             write(engine.evaluate(configuration));
         } catch (final IOException exception) {

--- a/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
@@ -3,6 +3,7 @@ package io.sease.rre.maven.plugin.external.elasticsearch;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sease.rre.core.Engine;
 import io.sease.rre.core.domain.Evaluation;
+import io.sease.rre.persistence.PersistenceConfiguration;
 import io.sease.rre.search.api.SearchPlatform;
 import io.sease.rre.search.api.impl.ExternalElasticsearch;
 import org.apache.maven.plugin.AbstractMojo;
@@ -52,6 +53,9 @@ public class RREvaluateMojo extends AbstractMojo {
     @Parameter(name = "exclude")
     private List<String> exclude;
 
+    @Parameter(name = "persistence")
+    private PersistenceConfiguration persistence = PersistenceConfiguration.DEFAULT_CONFIG;
+
     @Override
     public void execute() throws MojoExecutionException {
         final URL[] urls = compilePaths.stream()
@@ -79,7 +83,9 @@ public class RREvaluateMojo extends AbstractMojo {
                     metrics,
                     fields.split(","),
                     exclude,
-                    include);
+                    include,
+                    null,
+                    persistence);
 
             final Map<String, Object> configuration = Collections.emptyMap();
 

--- a/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
@@ -38,6 +38,15 @@ public class RREvaluateMojo extends AbstractMojo {
     @Parameter(name = "templates-folder", defaultValue = "${basedir}/src/etc/templates")
     private String templatesFolder;
 
+    @Parameter(name = "data-folder", defaultValue = "/tmp")
+    private String dataFolder;
+
+    @Parameter(name = "force-refresh", defaultValue = "true")
+    private boolean forceRefresh;
+
+    @Parameter(name = "checksum-file")
+    private String checksumFile;
+
     @Parameter(name = "metrics", defaultValue = "io.sease.rre.core.domain.metrics.impl.PrecisionAtOne,io.sease.rre.core.domain.metrics.impl.PrecisionAtTwo,io.sease.rre.core.domain.metrics.impl.PrecisionAtThree,io.sease.rre.core.domain.metrics.impl.PrecisionAtTen")
     private List<String> metrics;
 
@@ -62,10 +71,12 @@ public class RREvaluateMojo extends AbstractMojo {
                     metrics,
                     fields.split(","),
                     exclude,
-                    include);
+                    include,
+                    checksumFile);
 
             final Map<String, Object> configuration = new HashMap<>();
-            configuration.put("solr.home", "/tmp");
+            configuration.put("solr.home", dataFolder);
+            configuration.put("forceRefresh", forceRefresh);
 
             write(engine.evaluate(configuration));
         } catch (final IOException exception) {

--- a/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
@@ -38,7 +38,7 @@ public class RREvaluateMojo extends AbstractMojo {
     @Parameter(name = "templates-folder", defaultValue = "${basedir}/src/etc/templates")
     private String templatesFolder;
 
-    @Parameter(name = "data-folder", defaultValue = "/tmp")
+    @Parameter(name = "data-folder")
     private String dataFolder;
 
     @Parameter(name = "force-refresh", defaultValue = "true")
@@ -75,7 +75,9 @@ public class RREvaluateMojo extends AbstractMojo {
                     checksumFile);
 
             final Map<String, Object> configuration = new HashMap<>();
-            configuration.put("solr.home", dataFolder);
+            if (dataFolder != null && !dataFolder.isEmpty()) {
+                configuration.put("solr.home", dataFolder);
+            }
             configuration.put("forceRefresh", forceRefresh);
 
             write(engine.evaluate(configuration));

--- a/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
@@ -73,8 +73,8 @@ public class RREvaluateMojo extends AbstractMojo {
                     fields.split(","),
                     exclude,
                     include,
-                    persistence,
-                    checksumFile);
+                    checksumFile,
+                    persistence);
 
             final Map<String, Object> configuration = new HashMap<>();
             if (dataFolder != null && !dataFolder.isEmpty()) {

--- a/rre-search-platform/rre-search-platform-api/src/main/java/io/sease/rre/DirectoryUtils.java
+++ b/rre-search-platform/rre-search-platform-api/src/main/java/io/sease/rre/DirectoryUtils.java
@@ -1,0 +1,50 @@
+package io.sease.rre;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Objects;
+
+public class DirectoryUtils {
+
+    /**
+     * Recursively delete a directory. Will silently ignore directories that
+     * don't exist.
+     *
+     * @param deleteDir the directory to be deleted.
+     * @throws IOException if there are problems deleting the directory.
+     */
+    public static void deleteDirectory(File deleteDir) throws IOException {
+        if (deleteDir.exists()) {
+            Path directory = Paths.get(deleteDir.toURI());
+            Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+    }
+
+    public static void copyDirectory(File sourceLocation , File targetLocation) throws IOException {
+        if (sourceLocation.isDirectory()) {
+            if (!targetLocation.exists()) {
+                Files.createDirectory(targetLocation.toPath());
+            }
+
+            for (String child : Objects.requireNonNull(sourceLocation.list())) {
+                copyDirectory(new File(sourceLocation, child), new File(targetLocation, child));
+            }
+        } else {
+            Files.copy(sourceLocation.toPath(), targetLocation.toPath());
+        }
+    }
+}

--- a/rre-search-platform/rre-search-platform-api/src/main/java/io/sease/rre/DirectoryUtils.java
+++ b/rre-search-platform/rre-search-platform-api/src/main/java/io/sease/rre/DirectoryUtils.java
@@ -6,7 +6,12 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Objects;
 
-public class DirectoryUtils {
+/**
+ * Utilities for handling entire directories.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public abstract class DirectoryUtils {
 
     /**
      * Recursively delete a directory. Will silently ignore directories that
@@ -34,6 +39,14 @@ public class DirectoryUtils {
         }
     }
 
+    /**
+     * Copy an entire directory, with contents, from a source location to a
+     * destination.
+     *
+     * @param sourceLocation the File representing the source directory.
+     * @param targetLocation the File representing the destination.
+     * @throws IOException if any of the files cannot be coped.
+     */
     public static void copyDirectory(File sourceLocation , File targetLocation) throws IOException {
         if (sourceLocation.isDirectory()) {
             if (!targetLocation.exists()) {

--- a/rre-search-platform/rre-search-platform-api/src/main/java/io/sease/rre/search/api/SearchPlatform.java
+++ b/rre-search-platform/rre-search-platform-api/src/main/java/io/sease/rre/search/api/SearchPlatform.java
@@ -61,4 +61,13 @@ public interface SearchPlatform extends Closeable {
      * @return the name of this search platform.
      */
     String getName();
+
+    /**
+     * Does the platform require a refresh, outside of any concerns about
+     * corpora updates, etc. This is likely to be true when the data directory
+     * has been deleted, for example.
+     *
+     * @return {@code true} if the platform needs to be refreshed.
+     */
+    boolean isRefreshRequired();
 }

--- a/rre-search-platform/rre-search-platform-solr-impl/src/main/java/io/sease/rre/search/api/impl/ApacheSolr.java
+++ b/rre-search-platform/rre-search-platform-solr-impl/src/main/java/io/sease/rre/search/api/impl/ApacheSolr.java
@@ -34,8 +34,6 @@ import static java.util.Optional.ofNullable;
 public class ApacheSolr implements SearchPlatform {
     private final static Logger LOGGER = LogManager.getLogger(ApacheSolr.class);
 
-    private static final Logger LOGGER = LogManager.getLogger(ApacheSolr.class);
-
     private EmbeddedSolrServer proxy;
     private File solrHome;
     private File coreProperties;

--- a/rre-search-platform/rre-search-platform-solr-impl/src/main/java/io/sease/rre/search/api/impl/ApacheSolr.java
+++ b/rre-search-platform/rre-search-platform-solr-impl/src/main/java/io/sease/rre/search/api/impl/ApacheSolr.java
@@ -1,22 +1,21 @@
 package io.sease.rre.search.api.impl;
 
+import io.sease.rre.DirectoryUtils;
 import io.sease.rre.search.api.QueryOrSearchResponse;
 import io.sease.rre.search.api.SearchPlatform;
 import org.apache.htrace.fasterxml.jackson.databind.JsonNode;
 import org.apache.htrace.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.apache.solr.client.solrj.response.UpdateResponse;
-import org.apache.solr.core.CoreContainer;
+import org.apache.solr.common.SolrException;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -31,24 +30,32 @@ import static java.util.Optional.ofNullable;
  * @since 1.0
  */
 public class ApacheSolr implements SearchPlatform {
+    private final static Logger LOGGER = LogManager.getLogger(ApacheSolr.class);
 
     private EmbeddedSolrServer proxy;
     private File solrHome;
     private File coreProperties;
     private File renamedCoreProperties;
 
+    private boolean refreshRequired = false;
+
     @Override
     public void beforeStart(final Map<String, Object> configuration) {
         solrHome = new File(
-                (String) configuration.getOrDefault("solr.home", "/tmp"),
-                String.valueOf(System.currentTimeMillis()));
-        prepareSolrHome(solrHome);
+                (String) configuration.getOrDefault("solr.home", System.getProperty("java.io.tmpdir")));
 
-
-        final File parentDataDir = new File((String) configuration.getOrDefault("solr.data.dir", "/tmp"));
-        System.setProperty(
-                "solr.data.dir",
-                new File(parentDataDir, String.valueOf(System.currentTimeMillis())).getAbsolutePath());
+        if ((Boolean) configuration.get("forceRefresh") && solrHome.exists()) {
+            try {
+                DirectoryUtils.deleteDirectory(solrHome);
+            } catch (IOException e) {
+                LOGGER.error("Could not delete data directory - expect data to be stale!", e);
+            }
+        }
+        if (!solrHome.exists()) {
+            // If no data directory, refresh is required even if nothing else has changed
+            prepareSolrHome(solrHome);
+            refreshRequired = true;
+        }
 
         proxy = new EmbeddedSolrServer(solrHome.toPath(), "dummy");
     }
@@ -61,7 +68,27 @@ public class ApacheSolr implements SearchPlatform {
             coreProperties.renameTo(renamedCoreProperties);
         }
 
-        proxy.getCoreContainer().create(targetIndexName, configFolder.toPath(), emptyMap(), true);
+        // Copy files from configFolder into solrHome/targetIndexName
+        File targetIndexDir = new File(solrHome, targetIndexName);
+        try {
+            // Make sure the directory is deleted before copying to it
+            DirectoryUtils.deleteDirectory(targetIndexDir);
+            DirectoryUtils.copyDirectory(configFolder, targetIndexDir);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            // Using absolute path for the targetIndexDir, otherwise Solr can put the core.properties in the wrong place.
+            proxy.getCoreContainer().create(targetIndexName, targetIndexDir.toPath().toAbsolutePath(), emptyMap(), true);
+        } catch (SolrException e) {
+            if (e.code() == SolrException.ErrorCode.SERVER_ERROR.code) {
+                // Core already exists - ignore
+                LOGGER.debug("Core " + targetIndexName + " already exists - skipping index creation");
+            } else {
+                LOGGER.error("Caught Solr exception creating core :: " + e.getMessage());
+            }
+        }
 
         try {
             UpdateResponse response = new JsonUpdateRequest(new FileInputStream(data)).process(proxy, targetIndexName);
@@ -85,14 +112,14 @@ public class ApacheSolr implements SearchPlatform {
 
     @Override
     public void beforeStop() {
-        ofNullable(proxy).ifPresent(solr -> {
-            try {
-                solr.deleteByQuery("*:*");
-                solr.commit();
-            } catch (final Exception exception) {
-                exception.printStackTrace();
-            }
-        });
+//        ofNullable(proxy).ifPresent(solr -> {
+//            try {
+//                solr.deleteByQuery("*:*");
+//                solr.commit();
+//            } catch (final Exception exception) {
+//                exception.printStackTrace();
+//            }
+//        });
     }
 
     @Override
@@ -105,16 +132,16 @@ public class ApacheSolr implements SearchPlatform {
             }
         });
 
-        ofNullable(proxy)
-                .map(EmbeddedSolrServer::getCoreContainer)
-                .map(CoreContainer::getAllCoreNames)
-                .orElse(Collections.emptyList())
-                .forEach(coreName ->
-                            proxy.getCoreContainer().unload(coreName, true, true, false));
+//        ofNullable(proxy)
+//                .map(EmbeddedSolrServer::getCoreContainer)
+//                .map(CoreContainer::getAllCoreNames)
+//                .orElse(Collections.emptyList())
+//                .forEach(coreName ->
+//                            proxy.getCoreContainer().unload(coreName, true, true, false));
 
         ofNullable(renamedCoreProperties).ifPresent(file -> file.renameTo(coreProperties));
 
-        solrHome.deleteOnExit();
+//        solrHome.deleteOnExit();
     }
 
     @Override
@@ -146,6 +173,11 @@ public class ApacheSolr implements SearchPlatform {
     @Override
     public String getName() {
         return "Apache Solr";
+    }
+
+    @Override
+    public boolean isRefreshRequired() {
+        return refreshRequired;
     }
 
     /**


### PR DESCRIPTION
Modifications to allow semi-permanent external data directories to be
specified via the pom.xml. Remove need to re-ingest corpora every time
evaluation is run.

Squashed commit of the following:

commit f3c8390b7f36bf16b66a04018553f3202ecb8f1c
Author: Matt Pearce (OSC) <matthew.pierce@lexisnexis.co.uk>
Date:   Mon Nov 12 10:05:05 2018 +0000

    Drop forceRefresh parameter from Engine constructor.

commit 815347804646829933db5c8ef4beefcf5a30893c
Author: Matt Pearce (OSC) <matthew.pierce@lexisnexis.co.uk>
Date:   Thu Nov 8 16:59:13 2018 +0000

    Modify ES implementation to use recursive directory deletion.

commit 0d56caf20bc24ca3b07af964ffd0c76ddf10d406
Author: Matt Pearce (OSC) <matthew.pierce@lexisnexis.co.uk>
Date:   Thu Nov 8 16:58:12 2018 +0000

    Implement semi-permanent data directories for Solr.

commit 090088cac8b48e703d977b8006b5194eae155004
Author: Matt Pearce (OSC) <matthew.pierce@lexisnexis.co.uk>
Date:   Wed Nov 7 11:22:58 2018 +0000

    Implement file system checking via Engine class (ES only).

commit f3f8209a59c221802a1e76786903a9a1e23fedbb
Author: Matt Pearce (OSC) <matthew.pierce@lexisnexis.co.uk>
Date:   Tue Nov 6 13:30:56 2018 +0000

    Implement class to check for updates across directories, via checksum file.


