### PR TITLE
Allow connections to external Elasticsearch instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ target
 bin
 .idea
 .iml
+*.iml

--- a/rre-core/src/main/java/io/sease/rre/core/Engine.java
+++ b/rre-core/src/main/java/io/sease/rre/core/Engine.java
@@ -399,7 +399,7 @@ public class Engine {
 
         stream(versionFolders)
                 .flatMap(versionFolder -> stream(safe(versionFolder.listFiles(ONLY_NON_HIDDEN_FILES))))
-                .filter(platform::isSearchPlatformFile)
+                .filter(file -> platform.isSearchPlatformFile(indexName, file))
                 .peek(file -> LOGGER.info("RRE: Loading the Test Collection into " + platform.getName() + ", configuration version " + file.getParentFile().getName()))
                 .forEach(fileOrFolder -> platform.load(data, fileOrFolder, indexFqdn(indexName, fileOrFolder.getParentFile().getName())));
 

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/FMeasure.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/FMeasure.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * The F-measure measures the effectiveness of retrieval with respect to a user who attaches β times as much importance to recall as precision.
+ * The F-measure measures the effectiveness of retrieval with respect to a user who attaches (beta) times as much importance to recall as precision.
  * In statistical analysis of binary classification, the F1 score (also F-score or F-measure) is a measure of a test's accuracy.
  * It considers both the precision p and the recall r of the test to compute the score: p is the number of correct positive results
  * divided by the number of all positive results returned by the classifier, and r is the number of correct positive results

--- a/rre-maven-archetype/rre-maven-elasticsearch-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/rre-maven-archetype/rre-maven-elasticsearch-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,6 +5,18 @@
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
     <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <pluginRepositories>
+       <pluginRepository>
+          <id>sease</id>
+          <url>https://raw.github.com/SeaseLtd/rated-ranking-evaluator/mvn-repo</url>
+       </pluginRepository>
+    </pluginRepositories>
     <build>
         <plugins>
             <plugin>

--- a/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/pom.xml
+++ b/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/pom.xml
@@ -3,17 +3,11 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>rre</artifactId>
+        <artifactId>rre-maven-archetype</artifactId>
         <groupId>io.sease</groupId>
         <version>1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>rre-maven-archetype</artifactId>
-    <packaging>pom</packaging>
-    <name>RRE - Maven Archetypes</name>
-    <modules>
-        <module>rre-maven-solr-archetype</module>
-        <module>rre-maven-elasticsearch-archetype</module>
-        <module>rre-maven-external-elasticsearch-archetype</module>
-    </modules>
+    <artifactId>rre-maven-external-elasticsearch-archetype</artifactId>
+    <name>RRE - Maven External Elasticsearch Archetype</name>
 </project>

--- a/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,32 @@
+<archetype-descriptor xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
+                      name="RRE External Elasticsearch Project Layout" partial="true">
+    <requiredProperties>
+        <requiredProperty key="esVersion"/>
+    </requiredProperties>
+
+    <fileSets>
+        <fileSet encoding="UTF-8">
+            <directory>src/etc/ratings</directory>
+            <includes>
+                <include>ratings_example.json</include>
+                <include>README.md</include>
+            </includes>
+        </fileSet>
+        <fileSet encoding="UTF-8">
+            <directory>src/etc/templates</directory>
+            <includes>
+                <include>filtered_query_shape.json</include>
+                <include>no_filtered_query_shape.json</include>
+                <include>README.md</include>
+            </includes>
+        </fileSet>
+        <fileSet encoding="UTF-8">
+            <directory>src/etc/configuration_sets</directory>
+            <includes>
+                <include>*/**</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,79 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <pluginRepositories>
+       <pluginRepository>
+          <id>sease</id>
+          <url>https://raw.github.com/SeaseLtd/rated-ranking-evaluator/mvn-repo</url>
+       </pluginRepository>
+    </pluginRepositories>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.sease</groupId>
+                <artifactId>rre-maven-external-elasticsearch-plugin</artifactId>
+                <version>${esVersion}</version>
+                <!-- the configuration below is provided just for example, as it perfectly matches default values -->
+                <configuration>
+                    <configurations-folder>src/etc/configuration_sets</configurations-folder>
+                    <ratings-folder>src/etc/ratings</ratings-folder>
+                    <templates-folder>src/etc/templates</templates-folder>
+                    <fields>*,score</fields>
+                    <metrics>
+                        <param>io.sease.rre.core.domain.metrics.impl.Precision</param>
+                        <param>io.sease.rre.core.domain.metrics.impl.Recall</param>
+                        <param>io.sease.rre.core.domain.metrics.impl.ReciprocalRank</param>
+                        <param>io.sease.rre.core.domain.metrics.impl.AveragePrecision</param>
+                        <param>io.sease.rre.core.domain.metrics.impl.NDCGAtTen</param>
+                        <param>io.sease.rre.core.domain.metrics.impl.PrecisionAtOne</param>
+                        <param>io.sease.rre.core.domain.metrics.impl.PrecisionAtTwo</param>
+                        <param>io.sease.rre.core.domain.metrics.impl.PrecisionAtThree</param>
+                        <param>io.sease.rre.core.domain.metrics.impl.PrecisionAtTen</param>
+                    </metrics>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>search-quality-evaluation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>evaluate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.sease</groupId>
+                <artifactId>rre-maven-report-plugin</artifactId>
+                <version>1.0</version>
+                <configuration>
+                    <formats>
+                        <param>spreadsheet</param>
+                        <!-- IMPORTANT: uncomment the following line if you're running the RRE server -->
+                        <!--
+                            <param>rre-server</param>
+                        -->
+                    </formats>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>search-quality-evaluation-reporting</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/configuration_sets/README.md
+++ b/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/configuration_sets/README.md
@@ -1,0 +1,6 @@
+This folder contains one subfolder for each configuration version. 
+Each version folder should contain the index settings associated with such version:
+
+- `hostUrls`: an array of URLs where the Elasticsearch instance for this
+version can be accessed.
+- `index`: the name of the index holding the data being used to search.

--- a/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/configuration_sets/v1.0/index-settings.json
+++ b/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/configuration_sets/v1.0/index-settings.json
@@ -1,0 +1,4 @@
+{
+  "hostUrls": [ "http://localhost:9200" ],
+  "index": "music_v1.0"
+}

--- a/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/configuration_sets/v1.1/index-settings.json
+++ b/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/configuration_sets/v1.1/index-settings.json
@@ -1,0 +1,4 @@
+{
+  "hostUrls": [ "http://localhost:9200" ],
+  "index": "music_v1.1"
+}

--- a/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/ratings/ratings_example.json
+++ b/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/ratings/ratings_example.json
@@ -1,0 +1,73 @@
+{
+  "index": "basses",
+  "corpora_file": "electric_basses.bulk",
+  "id_field": "_id",
+  "topics": [
+    {
+      "description": "Fender basses",
+      "query_groups": [
+        {
+          "name": "Brand search",
+          "description": "The group tests several searches on the Fender brand",
+          "queries": [
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "fender"
+              }
+            },
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "Fender"
+              }
+            },
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "Fender bass"
+              }
+            }
+          ],
+          "relevant_documents": {
+            "1": {
+              "gain": 3
+            },
+            "2": {
+              "gain": 3
+            }
+          }
+        },
+        {
+          "name": "Jazz bass search",
+          "description": "Several searches on a given model (Jazz bass)",
+          "queries": [
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "jazz"
+              }
+            },
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "Jazz"
+              }
+            },
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "Jazz Bass"
+              }
+            }
+          ],
+          "relevant_documents": {
+            "1": {
+              "gain": 3
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/templates/README.md
+++ b/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/templates/README.md
@@ -1,0 +1,43 @@
+This folder will contain the query templates associated with the evaluation suite. 
+The query shape in Elasticsearch is already a JSON file so each template should be a valid Elasticsearch query 
+with all needed placeholders (that will be defined within the ratings file).
+
+```javascript
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "multi_match": {
+            "query": "$query",
+            "fields": [
+              "some_searchable_field_1^1.75",
+              "some_other_searchable_field"
+            ],
+            "minimum_should_match": "3<-45% 6<-95%"
+          }
+        }
+      ]
+    }
+  },
+  "aggs": {
+    "headings": {
+      "terms": {
+        "field": "title_sugg",
+        "order": { "max_score": "desc" }
+      },
+      "aggs": {
+        "max_score": {
+          "max": {
+            "script": {
+              "lang": "painless",
+              "inline": "_score"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/templates/filtered_query_shape.json
+++ b/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/templates/filtered_query_shape.json
@@ -1,0 +1,26 @@
+{
+  "query": {
+    "match": {
+      "name": {
+        "query": "$query",
+        "minimum_should_match": "3<-75% 9<-85%"
+      }
+    }
+  },
+  "filter": {
+    "bool": {
+      "should": [
+        {
+          "term": {
+            "number_of_strings": "$filter_1"
+          }
+        },
+        {
+          "term": {
+            "number_of_strings": "$filter_2"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/templates/no_filtered_query_shape.json
+++ b/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/templates/no_filtered_query_shape.json
@@ -1,0 +1,10 @@
+{
+  "query": {
+    "match": {
+      "name": {
+        "query": "$query",
+        "minimum_should_match": "3<-75% 9<-85%"
+      }
+    }
+  }
+}

--- a/rre-maven-archetype/rre-maven-solr-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/rre-maven-archetype/rre-maven-solr-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,6 +5,17 @@
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
     <packaging>pom</packaging>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <pluginRepositories>
+       <pluginRepository>
+          <id>sease</id>
+          <url>https://raw.github.com/SeaseLtd/rated-ranking-evaluator/mvn-repo</url>
+       </pluginRepository>
+    </pluginRepositories>         
     <build>
         <plugins>
             <plugin>

--- a/rre-maven-plugin/pom.xml
+++ b/rre-maven-plugin/pom.xml
@@ -14,6 +14,7 @@
         <module>rre-maven-solr-plugin</module>
         <module>rre-maven-report-plugin</module>
         <module>rre-maven-elasticsearch-plugin</module>
+        <module>rre-maven-external-elasticsearch-plugin</module>
     </modules>
     <packaging>pom</packaging>
     <properties>

--- a/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/pom.xml
+++ b/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>rre-maven-plugin</artifactId>
+        <groupId>io.sease</groupId>
+        <version>1.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rre-maven-external-elasticsearch-plugin</artifactId>
+    <version>6.3.2</version>
+    <packaging>maven-plugin</packaging>
+    <name>RRE - Maven External Elasticsearch Plugin</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.sease</groupId>
+            <artifactId>rre-search-platform-elasticsearch-impl</artifactId>
+            <version>6.3.2</version>
+        </dependency>
+        <!-- Specify Apache HTTP libraries, otherwise overridden by incompatible Maven versions -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,8 +46,11 @@ public class RREvaluateMojo extends AbstractMojo {
     @Parameter(name = "fields", defaultValue = "")
     private String fields;
 
-    @Parameter(name = "hosts", defaultValue = "http://localhost:9200", required = true)
-    private List<String> hosts;
+    @Parameter(name = "include")
+    private List<String> include;
+
+    @Parameter(name = "exclude")
+    private List<String> exclude;
 
     @Override
     public void execute() throws MojoExecutionException {
@@ -74,11 +78,10 @@ public class RREvaluateMojo extends AbstractMojo {
                     templatesFolder,
                     metrics,
                     fields.split(","),
-                    null,
-                    null);
+                    exclude,
+                    include);
 
-            final Map<String, Object> configuration = new HashMap<>();
-            configuration.put("hosts", hosts);
+            final Map<String, Object> configuration = Collections.emptyMap();
 
             write(engine.evaluate(configuration));
         } catch (final IOException exception) {

--- a/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
@@ -1,0 +1,102 @@
+package io.sease.rre.maven.plugin.external.elasticsearch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.sease.rre.core.Engine;
+import io.sease.rre.core.domain.Evaluation;
+import io.sease.rre.search.api.SearchPlatform;
+import io.sease.rre.search.api.impl.ExternalElasticsearch;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RRE Evaluation Mojo (External Elasticsearch settings).
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+@Mojo(name = "evaluate", inheritByDefault = false, defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
+public class RREvaluateMojo extends AbstractMojo {
+
+    @Parameter( defaultValue = "${project.compileClasspathElements}", readonly = true, required = true )
+    private List<String> compilePaths;
+
+    @Parameter(name = "configurations-folder", defaultValue = "${basedir}/src/etc/configuration_sets")
+    private String configurationsFolder;
+
+    @Parameter(name = "ratings-folder", defaultValue = "${basedir}/src/etc/ratings)")
+    private String ratingsFolder;
+
+    @Parameter(name = "templates-folder", defaultValue = "${basedir}/src/etc/templates")
+    private String templatesFolder;
+
+    @Parameter(name = "metrics", defaultValue = "io.sease.rre.core.domain.metrics.impl.PrecisionAtOne,io.sease.rre.core.domain.metrics.impl.PrecisionAtTwo,io.sease.rre.core.domain.metrics.impl.PrecisionAtThree,io.sease.rre.core.domain.metrics.impl.PrecisionAtTen")
+    private List<String> metrics;
+
+    @Parameter(name = "fields", defaultValue = "")
+    private String fields;
+
+    @Parameter(name = "hosts", defaultValue = "http://localhost:9200", required = true)
+    private List<String> hosts;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        final URL[] urls = compilePaths.stream()
+                .map(path -> {
+                    try {
+                        return new File(path).toURI().toURL();
+                    } catch (final Exception exception) {
+                        throw new IllegalArgumentException(exception);
+                    }})
+                .toArray(URL[]::new);
+
+        Thread.currentThread()
+                .setContextClassLoader(
+                        URLClassLoader.newInstance(
+                                urls,
+                                Thread.currentThread().getContextClassLoader()));
+
+        try (final SearchPlatform platform = new ExternalElasticsearch()) {
+            final Engine engine = new Engine(
+                    platform,
+                    configurationsFolder,
+                    null,
+                    ratingsFolder,
+                    templatesFolder,
+                    metrics,
+                    fields.split(","),
+                    null,
+                    null);
+
+            final Map<String, Object> configuration = new HashMap<>();
+            configuration.put("hosts", hosts);
+
+            write(engine.evaluate(configuration));
+        } catch (final IOException exception) {
+            throw new MojoExecutionException(exception.getMessage(), exception);
+        }
+    }
+
+    /**
+     * Writes out the evaluation result.
+     *
+     * @param evaluation the evaluation result.
+     * @throws IOException in case of I/O failure.
+     */
+    private void write(final Evaluation evaluation) throws IOException {
+        final File outputFolder = new File("target/rre");
+        outputFolder.mkdirs();
+
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.writerWithDefaultPrettyPrinter().writeValue(new File(outputFolder, "evaluation.json"), evaluation);
+    }
+}

--- a/rre-search-platform/rre-search-platform-api/src/main/java/io/sease/rre/search/api/SearchPlatform.java
+++ b/rre-search-platform/rre-search-platform-api/src/main/java/io/sease/rre/search/api/SearchPlatform.java
@@ -67,9 +67,16 @@ public interface SearchPlatform extends Closeable {
      * Ie. can it be used to initialise and/or configure a search platform
      * index?
      *
+     * @param indexName the index name being processed.
      * @param file the file to be tested.
      * @return {@code true} if the file is a search platform config file or
      * directory.
      */
-    boolean isSearchPlatformFile(File file);
+    boolean isSearchPlatformFile(String indexName, File file);
+
+    /**
+     * @return {@code true} if this platform requires a corpora file to be
+     * loaded in order to run.
+     */
+    boolean isCorporaRequired();
 }

--- a/rre-search-platform/rre-search-platform-elastic-search-impl/pom.xml
+++ b/rre-search-platform/rre-search-platform-elastic-search-impl/pom.xml
@@ -34,6 +34,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>

--- a/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/Elasticsearch.java
+++ b/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/Elasticsearch.java
@@ -256,4 +256,9 @@ public class Elasticsearch implements SearchPlatform {
     public boolean isSearchPlatformFile(String indexName, File file) {
         return file.isFile() && file.getName().equals("index-shape.json");
     }
+
+    @Override
+    public boolean isCorporaRequired() {
+        return true;
+    }
 }

--- a/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/Elasticsearch.java
+++ b/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/Elasticsearch.java
@@ -189,7 +189,7 @@ public class Elasticsearch implements SearchPlatform {
         try {
             final String q = mapper.writeValueAsString(mapper.readTree(query).get("query"));
             final SearchSourceBuilder qBuilder = new SearchSourceBuilder().query(QueryBuilders.wrapperQuery(q)).size(maxRows).fetchSource(fields, null);
-            final SearchResponse qresponse = proxy.search(new SearchRequest(indexName).source(qBuilder)).actionGet();
+            final SearchResponse qresponse = executeQuery(new SearchRequest(indexName).source(qBuilder));
             return new QueryOrSearchResponse(
                     qresponse.getHits().totalHits,
                     stream(qresponse.getHits().getHits())
@@ -202,6 +202,10 @@ public class Elasticsearch implements SearchPlatform {
         } catch (final IOException exception) {
             throw new RuntimeException(exception);
         }
+    }
+
+    protected SearchResponse executeQuery(SearchRequest request) throws IOException {
+        return proxy.search(request).actionGet();
     }
 
     @SuppressWarnings("unchecked")
@@ -249,7 +253,7 @@ public class Elasticsearch implements SearchPlatform {
     }
 
     @Override
-    public boolean isSearchPlatformFile(File file) {
+    public boolean isSearchPlatformFile(String indexName, File file) {
         return file.isFile() && file.getName().equals("index-shape.json");
     }
 }

--- a/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/ExternalElasticsearch.java
+++ b/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/ExternalElasticsearch.java
@@ -7,6 +7,7 @@ import io.sease.rre.search.api.QueryOrSearchResponse;
 import org.apache.http.HttpHost;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RestClient;
@@ -14,6 +15,7 @@ import org.elasticsearch.client.RestHighLevelClient;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +81,9 @@ public class ExternalElasticsearch extends Elasticsearch {
             final SearchRequest request = buildSearchRequest(indexSettingsMap.get(indexName).getIndex(), query, fields, maxRows);
             final SearchResponse response = runQuery(indexName, request);
             return convertResponse(response);
+        } catch (final ElasticsearchException e) {
+            LOGGER.error("Caught ElasticsearchException :: " + e.getMessage());
+            return new QueryOrSearchResponse(0, Collections.emptyList());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/ExternalElasticsearch.java
+++ b/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/ExternalElasticsearch.java
@@ -1,0 +1,118 @@
+package io.sease.rre.search.api.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.sease.rre.search.api.QueryOrSearchResponse;
+import org.apache.http.HttpHost;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * SearchPlatform implementation for connecting to and reading from an external
+ * Elasticsearch instance.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public class ExternalElasticsearch extends Elasticsearch {
+
+    private static final Logger LOGGER = LogManager.getLogger(ExternalElasticsearch.class);
+    private static final String NAME = "External Elasticsearch";
+    static final String SETTINGS_FILE = "index-settings.json";
+
+    private RestHighLevelClient client;
+
+    private final Map<String, IndexSettings> indexSettingsMap = new HashMap<>();
+
+    @Override
+    public void beforeStart(Map<String, Object> configuration) {
+        HttpHost[] hosts = ((List<String>) configuration.get("hosts")).stream()
+                .map(HttpHost::create)
+                .toArray(HttpHost[]::new);
+
+        client = new RestHighLevelClient(RestClient.builder(hosts));
+    }
+
+    @Override
+    public void start() {
+        // No-op for this implementation
+    }
+
+    @Override
+    public void load(File corpus, File settingsFile, String targetIndexName) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        try {
+            // Load the index settings for this version of the index
+            IndexSettings settings = mapper.readValue(settingsFile, IndexSettings.class);
+            indexSettingsMap.put(targetIndexName, settings);
+        } catch (IOException e) {
+            LOGGER.error("Could not read settings from " + settingsFile.getName() + " :: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public QueryOrSearchResponse executeQuery(String indexName, String query, String[] fields, int maxRows) {
+        // Find the actual index to search
+        if (!indexSettingsMap.containsKey(indexName)) {
+            throw new IllegalArgumentException("Cannot find settings for index " + indexName);
+        }
+
+        return super.executeQuery(indexSettingsMap.get(indexName).getIndex(), query, fields, maxRows);
+    }
+
+    @Override
+    protected SearchResponse executeQuery(SearchRequest request) throws IOException {
+        return client.search(request);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean isSearchPlatformFile(String indexName, File file) {
+        return file.isFile() && file.getName().equals(SETTINGS_FILE);
+    }
+
+    @Override
+    public boolean isCorporaRequired() {
+        return false;
+    }
+
+    @Override
+    public void close() {
+        try {
+            client.close();
+        } catch (IOException e) {
+            LOGGER.error("Caught IOException closing ES HTTP client :: " + e.getMessage());
+        }
+    }
+
+
+    public static class IndexSettings {
+
+        @JsonProperty("index")
+        private final String index;
+
+        public IndexSettings(@JsonProperty("index") String index) {
+            this.index = index;
+        }
+
+        public String getIndex() {
+            return index;
+        }
+    }
+}

--- a/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/ExternalElasticsearch.java
+++ b/rre-search-platform/rre-search-platform-elastic-search-impl/src/main/java/io/sease/rre/search/api/impl/ExternalElasticsearch.java
@@ -77,14 +77,14 @@ public class ExternalElasticsearch extends Elasticsearch {
 
         try {
             final SearchRequest request = buildSearchRequest(indexSettingsMap.get(indexName).getIndex(), query, fields, maxRows);
-            final SearchResponse response = executeQuery(indexName, request);
+            final SearchResponse response = runQuery(indexName, request);
             return convertResponse(response);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private SearchResponse executeQuery(final String indexKey, final SearchRequest request) throws IOException {
+    private SearchResponse runQuery(final String indexKey, final SearchRequest request) throws IOException {
         RestHighLevelClient client = indexClients.get(indexKey);
         if (client == null) {
             throw new RuntimeException("No HTTP client found for index " + indexKey);

--- a/rre-search-platform/rre-search-platform-elastic-search-impl/src/test/java/io/sease/rre/search/api/impl/ElasticsearchTest.java
+++ b/rre-search-platform/rre-search-platform-elastic-search-impl/src/test/java/io/sease/rre/search/api/impl/ElasticsearchTest.java
@@ -13,6 +13,8 @@ import static org.junit.Assert.assertTrue;
 
 public class ElasticsearchTest {
 
+    private static final String INDEX_NAME = "test";
+
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -26,18 +28,18 @@ public class ElasticsearchTest {
     @Test
     public void isSearchPlatformFile_returnsFalseWhenDirectory() throws Exception {
         File dummyFile = tempFolder.newFolder();
-        assertFalse(platform.isSearchPlatformFile(dummyFile));
+        assertFalse(platform.isSearchPlatformFile(INDEX_NAME, dummyFile));
     }
 
     @Test
     public void isSearchPlatformFile_returnsFalseWhenFileIsNotESConfig() throws Exception {
         File dummyFile = tempFolder.newFile();
-        assertFalse(platform.isSearchPlatformFile(dummyFile));
+        assertFalse(platform.isSearchPlatformFile(INDEX_NAME, dummyFile));
     }
 
     @Test
-    public void isSearchPlatformFile_returnsTrueWhenDirectoryContainsSolrConfig() throws Exception {
+    public void isSearchPlatformFile_returnsTrueWhenDirectoryContainsConfig() throws Exception {
         File configFile = tempFolder.newFile("index-shape.json");
-        assertTrue(platform.isSearchPlatformFile(configFile));
+        assertTrue(platform.isSearchPlatformFile(INDEX_NAME, configFile));
     }
 }

--- a/rre-search-platform/rre-search-platform-elastic-search-impl/src/test/java/io/sease/rre/search/api/impl/ExternalElasticsearchTest.java
+++ b/rre-search-platform/rre-search-platform-elastic-search-impl/src/test/java/io/sease/rre/search/api/impl/ExternalElasticsearchTest.java
@@ -1,0 +1,45 @@
+package io.sease.rre.search.api.impl;
+
+import io.sease.rre.search.api.SearchPlatform;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ExternalElasticsearchTest {
+
+    private static final String INDEX_NAME = "test";
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private SearchPlatform platform;
+
+    @Before
+    public void setupPlatform() {
+        platform = new ExternalElasticsearch();
+    }
+
+    @Test
+    public void isSearchPlatformFile_returnsFalseWhenDirectory() throws Exception {
+        File dummyFile = tempFolder.newFolder();
+        assertFalse(platform.isSearchPlatformFile(INDEX_NAME, dummyFile));
+    }
+
+    @Test
+    public void isSearchPlatformFile_returnsFalseWhenFileIsNotESConfig() throws Exception {
+        File dummyFile = tempFolder.newFile();
+        assertFalse(platform.isSearchPlatformFile(INDEX_NAME, dummyFile));
+    }
+
+    @Test
+    public void isSearchPlatformFile_returnsTrueWhenDirectoryContainsConfig() throws Exception {
+        File configFile = tempFolder.newFile(ExternalElasticsearch.SETTINGS_FILE);
+        assertTrue(platform.isSearchPlatformFile(INDEX_NAME, configFile));
+    }
+}

--- a/rre-search-platform/rre-search-platform-solr-impl/src/main/java/io/sease/rre/search/api/impl/ApacheSolr.java
+++ b/rre-search-platform/rre-search-platform-solr-impl/src/main/java/io/sease/rre/search/api/impl/ApacheSolr.java
@@ -173,14 +173,7 @@ public class ApacheSolr implements SearchPlatform {
     }
 
     @Override
-    public boolean isSearchPlatformFile(File file) {
-        boolean ret = false;
-
-        if (file.isDirectory()) {
-            String[] fileContent = file.list((dir, name) -> (name.equals("solrconfig.xml")));
-            ret = fileContent.length == 1;
-        }
-
-        return ret;
+    public boolean isSearchPlatformFile(String indexName, File file) {
+        return file.isDirectory() && file.getName().equals(indexName);
     }
 }

--- a/rre-search-platform/rre-search-platform-solr-impl/src/main/java/io/sease/rre/search/api/impl/ApacheSolr.java
+++ b/rre-search-platform/rre-search-platform-solr-impl/src/main/java/io/sease/rre/search/api/impl/ApacheSolr.java
@@ -176,4 +176,9 @@ public class ApacheSolr implements SearchPlatform {
     public boolean isSearchPlatformFile(String indexName, File file) {
         return file.isDirectory() && file.getName().equals(indexName);
     }
+
+    @Override
+    public boolean isCorporaRequired() {
+        return true;
+    }
 }

--- a/rre-search-platform/rre-search-platform-solr-impl/src/test/java/io/sease/rre/search/api/impl/ApacheSolrTest.java
+++ b/rre-search-platform/rre-search-platform-solr-impl/src/test/java/io/sease/rre/search/api/impl/ApacheSolrTest.java
@@ -13,6 +13,8 @@ import static org.junit.Assert.assertTrue;
 
 public class ApacheSolrTest {
 
+    private static final String INDEX_NAME = "test";
+
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -26,17 +28,17 @@ public class ApacheSolrTest {
     @Test
     public void isSearchPlatformFile_returnsFalseWhenNotDirectory() throws Exception {
         File dummyFile = tempFolder.newFile();
-        assertFalse(platform.isSearchPlatformFile(dummyFile));
+        assertFalse(platform.isSearchPlatformFile(INDEX_NAME, dummyFile));
     }
 
     @Test
     public void isSearchPlatformFile_returnsFalseWhenDirectoryNotContainSolrConfig() {
-        assertFalse(platform.isSearchPlatformFile(tempFolder.getRoot()));
+        assertFalse(platform.isSearchPlatformFile(INDEX_NAME, tempFolder.getRoot()));
     }
 
     @Test
     public void isSearchPlatformFile_returnsTrueWhenDirectoryContainsSolrConfig() throws Exception {
-        File configFile = tempFolder.newFile("solrconfig.xml");
-        assertTrue(platform.isSearchPlatformFile(tempFolder.getRoot()));
+        File configFile = tempFolder.newFolder(INDEX_NAME);
+        assertTrue(platform.isSearchPlatformFile(INDEX_NAME, configFile));
     }
 }


### PR DESCRIPTION
This patch adds a new Maven plugin, allowing the user to specify external Elasticsearch indices to use to generate their metrics. It assumes that the external ES instances have already been created, contain data, and are ready to query.

I've also included an archetype, although without the base data set I'm not sure how useful it is.