### PR TITLE
Persistence framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ target
 bin
 .idea
 .iml
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <jackson.version>2.9.4</jackson.version>
         <github.global.server>github</github.global.server>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <developers>
         <developer>

--- a/rre-core/src/main/java/io/sease/rre/core/domain/DomainMember.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/DomainMember.java
@@ -1,5 +1,6 @@
 package io.sease.rre.core.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.sease.rre.core.domain.metrics.Metric;
 import io.sease.rre.core.domain.metrics.impl.AveragedMetric;
@@ -123,5 +124,10 @@ public abstract class DomainMember<C extends DomainMember> {
 
     public Map<String, Metric> getMetrics() {
         return metrics;
+    }
+
+    @JsonIgnore
+    public Optional<DomainMember> getParent() {
+        return ofNullable(parent);
     }
 }

--- a/rre-core/src/main/java/io/sease/rre/persistence/PersistenceConfiguration.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/PersistenceConfiguration.java
@@ -70,6 +70,16 @@ public class PersistenceConfiguration {
         return handlerConfiguration;
     }
 
+    /**
+     * Get the configuration for an individual handler, returning a map of
+     * configuration items keyed by the String value of their name. If there
+     * is no configuration, an empty map will be returned.
+     *
+     * @param name the name of the handler whose configuration is required.
+     * @return a String:Object map containing the configuration. Never
+     * {@code null}.
+     */
+    @SuppressWarnings("unchecked")
     public Map<String, Object> getHandlerConfigurationByName(String name) {
         Map<String, Object> configMap = new HashMap<>();
 

--- a/rre-core/src/main/java/io/sease/rre/persistence/PersistenceConfiguration.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/PersistenceConfiguration.java
@@ -1,0 +1,89 @@
+package io.sease.rre.persistence;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration details for the persistence manager.
+ * <p>
+ * Configuration consists of a set of handler names, mapped to their
+ * implementation classes. The handler names are then used to refer to
+ * specific sets of configuration details, allowing the same implementation
+ * to be used multiple times with separate destinations (for example).
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public class PersistenceConfiguration {
+
+    /**
+     * Default configuration object, with configuration for persisting to
+     * a single JSON output file.
+     */
+    public static final PersistenceConfiguration DEFAULT_CONFIG = defaultConfiguration();
+
+    private boolean useTimestampAsVersion = false;
+    private Map<String, String> handlers;
+    // Supplying type params for nested map breaks Maven initialisation
+    private Map<String, Map> handlerConfiguration;
+
+    public PersistenceConfiguration() {
+        // Do nothing - required for Maven initialisation
+    }
+
+    PersistenceConfiguration(boolean useTimestampAsVersion,
+                             Map<String, String> handlers,
+                             Map<String, Map> handlerConfiguration) {
+        this.useTimestampAsVersion = useTimestampAsVersion;
+        this.handlers = handlers;
+        this.handlerConfiguration = handlerConfiguration;
+    }
+
+    /**
+     * Should the persistence framework use a timestamp in place of the
+     * configuration version? This timestamp should be consistent for
+     * the duration of the evaluation.
+     * <p>
+     * This will take effect when there is only one configuration set
+     * available - eg. for users who modify the same configuration set
+     * rather than creating a separate one each iteration.
+     *
+     * @return {@code true} if a timestamp should be used in place of the
+     * version string when persisting query output.
+     */
+    public boolean isUseTimestampAsVersion() {
+        return useTimestampAsVersion;
+    }
+
+    /**
+     * @return a map of handler name to implementation classes.
+     */
+    public Map<String, String> getHandlers() {
+        return handlers;
+    }
+
+    /**
+     * @return a map of handler name to a map containing configuration
+     * details for the handler.
+     */
+    public Map<String, Map> getHandlerConfiguration() {
+        return handlerConfiguration;
+    }
+
+    /**
+     * Build a default PersistenceConfiguration, with handlers set to write
+     * to the standard JSON output file.
+     *
+     * @return a PersistenceConfiguration object.
+     */
+    private static PersistenceConfiguration defaultConfiguration() {
+        final String jsonKey = "json";
+        Map<String, String> handlers = new HashMap<>();
+        handlers.put(jsonKey, "io.sease.rre.persistence.impl.JsonPersistenceHandler");
+        Map<String, Object> jsonConfig = new HashMap<>();
+        jsonConfig.put("outputFile", "target/rre/evaluation.json");
+        Map<String, Map> handlerConfig = new HashMap<>();
+        handlerConfig.put(jsonKey, jsonConfig);
+
+        return new PersistenceConfiguration(false, handlers, handlerConfig);
+    }
+}

--- a/rre-core/src/main/java/io/sease/rre/persistence/PersistenceConfiguration.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/PersistenceConfiguration.java
@@ -26,13 +26,14 @@ public class PersistenceConfiguration {
     // Supplying type params for nested map breaks Maven initialisation
     private Map<String, Map> handlerConfiguration;
 
+    @SuppressWarnings("unused")
     public PersistenceConfiguration() {
         // Do nothing - required for Maven initialisation
     }
 
-    PersistenceConfiguration(boolean useTimestampAsVersion,
-                             Map<String, String> handlers,
-                             Map<String, Map> handlerConfiguration) {
+    private PersistenceConfiguration(boolean useTimestampAsVersion,
+                                     Map<String, String> handlers,
+                                     Map<String, Map> handlerConfiguration) {
         this.useTimestampAsVersion = useTimestampAsVersion;
         this.handlers = handlers;
         this.handlerConfiguration = handlerConfiguration;
@@ -67,6 +68,16 @@ public class PersistenceConfiguration {
      */
     public Map<String, Map> getHandlerConfiguration() {
         return handlerConfiguration;
+    }
+
+    public Map<String, Object> getHandlerConfigurationByName(String name) {
+        Map<String, Object> configMap = new HashMap<>();
+
+        if (handlerConfiguration.get(name) != null) {
+            handlerConfiguration.get(name).forEach((k, v) -> configMap.put(String.valueOf(k), v));
+        }
+
+        return configMap;
     }
 
     /**

--- a/rre-core/src/main/java/io/sease/rre/persistence/PersistenceException.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/PersistenceException.java
@@ -1,0 +1,25 @@
+package io.sease.rre.persistence;
+
+/**
+ * Exception thrown by the persistence framework.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public class PersistenceException extends Exception {
+
+    public PersistenceException() {
+        super();
+    }
+
+    public PersistenceException(String message) {
+        super(message);
+    }
+
+    public PersistenceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PersistenceException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/rre-core/src/main/java/io/sease/rre/persistence/PersistenceHandler.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/PersistenceHandler.java
@@ -1,0 +1,51 @@
+package io.sease.rre.persistence;
+
+import io.sease.rre.core.domain.Query;
+
+import java.util.Map;
+
+/**
+ * A persistence handler can be used to record the output from all queries
+ * run during an evaluation.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public interface PersistenceHandler {
+
+    /**
+     * Configure the persistence handler implementation.
+     *
+     * @param name          the name given to the handler in the main configuration.
+     * @param configuration the configuration parameters specific to the
+     *                      handler.
+     */
+    void configure(String name, Map<String, Object> configuration);
+
+    /**
+     * Execute any necessary tasks required to initialise the handler.
+     */
+    void beforeStart();
+
+    /**
+     * Execute any necessary start-up tasks.
+     */
+    void start();
+
+    /**
+     * Record a query.
+     * @param q the query.
+     */
+    void recordQuery(Query q);
+
+    /**
+     * Execute any tasks necessary before stopping - for example, writing out
+     * buffered content.
+     */
+    void beforeStop();
+
+    /**
+     * Execute any necessary shutdown tasks - for example, closing output
+     * streams.
+     */
+    void stop();
+}

--- a/rre-core/src/main/java/io/sease/rre/persistence/PersistenceHandler.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/PersistenceHandler.java
@@ -7,6 +7,11 @@ import java.util.Map;
 /**
  * A persistence handler can be used to record the output from all queries
  * run during an evaluation.
+ * <p>
+ * Exceptions during processing are expected to be handled internally.
+ * Exceptions thrown during the {@link #beforeStart()} and {@link #start()}
+ * stages may be passed up the stack, to alert the PersistenceManager that
+ * the handler could not be started for some reason.
  *
  * @author Matt Pearce (matt@flax.co.uk)
  */
@@ -22,17 +27,30 @@ public interface PersistenceHandler {
     void configure(String name, Map<String, Object> configuration);
 
     /**
-     * Execute any necessary tasks required to initialise the handler.
+     * @return the configuration name for this handler instance.
      */
-    void beforeStart();
+    String getName();
+
+    /**
+     * Execute any necessary tasks required to initialise the handler.
+     *
+     * @throws PersistenceException if any pre-start checks fail. This should
+     *                              be used to report breaking failures - eg. issues that will stop the
+     *                              handler from starting.
+     */
+    void beforeStart() throws PersistenceException;
 
     /**
      * Execute any necessary start-up tasks.
+     *
+     * @throws PersistenceException if the handler cannot be started for any
+     *                              reason.
      */
-    void start();
+    void start() throws PersistenceException;
 
     /**
      * Record a query.
+     *
      * @param q the query.
      */
     void recordQuery(Query q);

--- a/rre-core/src/main/java/io/sease/rre/persistence/PersistenceManager.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/PersistenceManager.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -28,32 +29,35 @@ public class PersistenceManager {
     private final List<PersistenceHandler> handlers = new ArrayList<>();
 
     public void registerHandler(PersistenceHandler handler) {
+        LOGGER.info("Registering handler " + handler.getName() + " -> " + handler.getClass().getCanonicalName());
         handlers.add(handler);
     }
 
-    public void beforeStart() throws PersistenceException {
-        handlers.parallelStream().forEach(h -> {
+    public void beforeStart() {
+        for (Iterator<PersistenceHandler> it = handlers.iterator(); it.hasNext(); ) {
+            PersistenceHandler h = it.next();
             try {
                 h.beforeStart();
             } catch (PersistenceException e) {
                 LOGGER.error("beforeStart failed for handler [" + h.getName() + "] :: " + e.getMessage());
-                handlers.remove(h);
+                it.remove();
             }
-        });
+        }
 
         // Check that there are handlers available
         checkHandlers();
     }
 
     public void start() {
-        handlers.parallelStream().forEach(h -> {
+        for (Iterator<PersistenceHandler> it = handlers.iterator(); it.hasNext(); ) {
+            PersistenceHandler h = it.next();
             try {
                 h.start();
             } catch (PersistenceException e) {
                 LOGGER.error("[" + h.getName() + "] failed to start :: " + e.getMessage());
-                handlers.remove(h);
+                it.remove();
             }
-        });
+        }
 
         checkHandlers();
     }

--- a/rre-core/src/main/java/io/sease/rre/persistence/PersistenceManager.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/PersistenceManager.java
@@ -1,0 +1,49 @@
+package io.sease.rre.persistence;
+
+import io.sease.rre.core.domain.Query;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The general manager class for all persistence handlers. This provides
+ * methods for starting, processing, and shutting down a number of handlers
+ * via single method calls.
+ * <p>
+ * Persistence handlers should be constructed outside the manager, including
+ * any required initialisation via the {@link PersistenceHandler#configure(String, Map)}
+ * method, then registered using {@link #registerHandler(PersistenceHandler)}.
+ * <p>
+ * Most other methods apply to all registered handlers.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public class PersistenceManager {
+
+    private final List<PersistenceHandler> handlers = new ArrayList<>();
+
+    public void registerHandler(PersistenceHandler handler) {
+        handlers.add(handler);
+    }
+
+    public void beforeStart() {
+        handlers.parallelStream().forEach(PersistenceHandler::beforeStart);
+    }
+
+    public void start() {
+        handlers.parallelStream().forEach(PersistenceHandler::start);
+    }
+
+    public void recordQuery(Query query) {
+        handlers.parallelStream().forEach(h -> h.recordQuery(query));
+    }
+
+    public void beforeStop() {
+        handlers.parallelStream().forEach(PersistenceHandler::beforeStop);
+    }
+
+    public void stop() {
+        handlers.parallelStream().forEach(PersistenceHandler::stop);
+    }
+}

--- a/rre-core/src/main/java/io/sease/rre/persistence/impl/JsonPersistenceHandler.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/impl/JsonPersistenceHandler.java
@@ -14,6 +14,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -54,16 +56,25 @@ public class JsonPersistenceHandler implements PersistenceHandler {
     @Override
     public void beforeStart() throws PersistenceException {
         // Delete the output file if it already exists
-        File outFile = new File(outputFilepath);
-        if (outFile.exists()) {
+        Path outPath = Paths.get(outputFilepath);
+        if (Files.exists(outPath)) {
             try {
-                Files.delete(outFile.toPath());
+                Files.delete(outPath);
             } catch (IOException e) {
                 throw new PersistenceException("Cannot delete pre-existing output file " + outputFilepath, e);
             }
+        } else {
+            // Make sure the file's parent directory exists
+            if (outPath.getParent() != null) {
+                try {
+                    Files.createDirectories(outPath.getParent());
+                } catch (IOException e) {
+                    throw new PersistenceException("Cannot create output directory " + outPath.getParent(), e);
+                }
+            }
         }
 
-        try (FileOutputStream fos = new FileOutputStream(outFile)) {
+        try (FileOutputStream fos = new FileOutputStream(outPath.toFile())) {
             fos.write(new byte[0]);
         } catch (IOException e) {
             throw new PersistenceException("Cannot write to output file " + outputFilepath, e);

--- a/rre-core/src/main/java/io/sease/rre/persistence/impl/JsonPersistenceHandler.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/impl/JsonPersistenceHandler.java
@@ -1,0 +1,123 @@
+package io.sease.rre.persistence.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import io.sease.rre.core.domain.DomainMember;
+import io.sease.rre.core.domain.Evaluation;
+import io.sease.rre.core.domain.Query;
+import io.sease.rre.persistence.PersistenceException;
+import io.sease.rre.persistence.PersistenceHandler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * JSON implementation of the {@link PersistenceHandler} interface.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public class JsonPersistenceHandler implements PersistenceHandler {
+
+    static final String DESTINATION_FILE_CONFIGKEY = "destinationFile";
+    static final String PRETTY_CONFIGKEY = "pretty";
+
+    private static final String DEFAULT_OUTPUT_FILE = "target/rre/evaluation.json";
+
+    private static final Logger LOGGER = LogManager.getLogger(JsonPersistenceHandler.class);
+
+    private String name;
+    private String outputFilepath;
+    private boolean pretty;
+
+    private List<Query> queries = new ArrayList<>();
+
+    @Override
+    public void configure(String name, Map<String, Object> configuration) {
+        this.name = name;
+        this.outputFilepath = configuration.getOrDefault(DESTINATION_FILE_CONFIGKEY, DEFAULT_OUTPUT_FILE).toString();
+        this.pretty = Boolean.valueOf(configuration.getOrDefault(PRETTY_CONFIGKEY, "false").toString());
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void beforeStart() throws PersistenceException {
+        // Delete the output file if it already exists
+        File outFile = new File(outputFilepath);
+        if (outFile.exists()) {
+            try {
+                Files.delete(outFile.toPath());
+            } catch (IOException e) {
+                throw new PersistenceException("Cannot delete pre-existing output file " + outputFilepath, e);
+            }
+        }
+
+        try (FileOutputStream fos = new FileOutputStream(outFile)) {
+            fos.write(new byte[0]);
+        } catch (IOException e) {
+            throw new PersistenceException("Cannot write to output file " + outputFilepath, e);
+        }
+    }
+
+    @Override
+    public void start() {
+        // Nothing to start
+    }
+
+    @Override
+    public void recordQuery(Query q) {
+        queries.add(q);
+    }
+
+    @Override
+    public void beforeStop() {
+        // Collect the metrics for all of the queries
+        queries.forEach(Query::notifyCollectedMetrics);
+
+        // Retrieve the top level item
+        DomainMember topLevel = findTopLevel();
+        try {
+            // Write out the JSON object
+            ObjectMapper mapper = new ObjectMapper();
+            ObjectWriter writer = (pretty ? mapper.writerWithDefaultPrettyPrinter() : mapper.writer());
+            writer.writeValue(new File(outputFilepath), topLevel);
+        } catch (IOException e) {
+            LOGGER.error("Caught IOException writing queries to JSON :: " + e.getMessage());
+        }
+    }
+
+    private Optional<DomainMember<?>> retrieveParent(DomainMember<?> dm) {
+        if (dm.getParent().isPresent()) {
+            return retrieveParent(dm.getParent().get());
+        } else {
+            return Optional.of(dm);
+        }
+    }
+
+    private DomainMember findTopLevel() {
+        if (queries.size() > 0) {
+            // Get the first query, then iterate through the parents to the top
+            return retrieveParent(queries.get(0)).orElse(new Evaluation());
+        } else {
+            // No queries - return an empty Evaluation object
+            LOGGER.warn("No queries recorded - returning empty evaluation");
+            return new Evaluation();
+        }
+    }
+
+    @Override
+    public void stop() {
+        // Nothing to stop
+    }
+}

--- a/rre-core/src/main/java/io/sease/rre/persistence/impl/JsonPersistenceHandler.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/impl/JsonPersistenceHandler.java
@@ -31,7 +31,7 @@ public class JsonPersistenceHandler implements PersistenceHandler {
     static final String DESTINATION_FILE_CONFIGKEY = "destinationFile";
     static final String PRETTY_CONFIGKEY = "pretty";
 
-    private static final String DEFAULT_OUTPUT_FILE = "target/rre/evaluation.json";
+    public static final String DEFAULT_OUTPUT_FILE = "target/rre/evaluation.json";
 
     private static final Logger LOGGER = LogManager.getLogger(JsonPersistenceHandler.class);
 

--- a/rre-core/src/test/java/io/sease/rre/persistence/PersistenceManagerTest.java
+++ b/rre-core/src/test/java/io/sease/rre/persistence/PersistenceManagerTest.java
@@ -5,7 +5,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ConcurrentModificationException;
 import java.util.Map;
+
+import static org.junit.Assert.fail;
 
 /**
  * Unit tests for the PersistenceManager class.
@@ -26,16 +29,28 @@ public class PersistenceManagerTest {
         this.persistenceManager = null;
     }
 
-    @Test(expected = RuntimeException.class)
-    public void managerThrowsRuntimeException_whenAllHandlersFailBeforeStart() throws Exception {
-        persistenceManager.registerHandler(failingHandler);
-        persistenceManager.beforeStart();
+    @Test
+    public void managerThrowsRuntimeException_whenAllHandlersFailBeforeStart() {
+        try {
+            persistenceManager.registerHandler(failingHandler);
+            persistenceManager.beforeStart();
+        } catch (ConcurrentModificationException e) {
+            fail("Unexpected ConcurrentModificationException: " + e.getMessage());
+        } catch (RuntimeException e) {
+            // Expected
+        }
     }
 
-    @Test(expected = RuntimeException.class)
-    public void managerThrowsRuntimeException_whenAllHandlersFailStart() throws Exception {
-        persistenceManager.registerHandler(failingHandler);
-        persistenceManager.start();
+    @Test
+    public void managerThrowsRuntimeException_whenAllHandlersFailStart() {
+        try {
+            persistenceManager.registerHandler(failingHandler);
+            persistenceManager.start();
+        } catch (ConcurrentModificationException e) {
+            fail("Unexpected ConcurrentModificationException: " + e.getMessage());
+        } catch (RuntimeException e) {
+            // Expected
+        }
     }
 
     private PersistenceHandler failingHandler = new PersistenceHandler() {

--- a/rre-core/src/test/java/io/sease/rre/persistence/PersistenceManagerTest.java
+++ b/rre-core/src/test/java/io/sease/rre/persistence/PersistenceManagerTest.java
@@ -1,0 +1,72 @@
+package io.sease.rre.persistence;
+
+import io.sease.rre.core.domain.Query;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+/**
+ * Unit tests for the PersistenceManager class.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public class PersistenceManagerTest {
+
+    private PersistenceManager persistenceManager;
+
+    @Before
+    public void setupManager() {
+        this.persistenceManager = new PersistenceManager();
+    }
+
+    @After
+    public void tearDownManager() {
+        this.persistenceManager = null;
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void managerThrowsRuntimeException_whenAllHandlersFailBeforeStart() throws Exception {
+        persistenceManager.registerHandler(failingHandler);
+        persistenceManager.beforeStart();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void managerThrowsRuntimeException_whenAllHandlersFailStart() throws Exception {
+        persistenceManager.registerHandler(failingHandler);
+        persistenceManager.start();
+    }
+
+    private PersistenceHandler failingHandler = new PersistenceHandler() {
+        @Override
+        public void configure(String name, Map<String, Object> configuration) { }
+
+        @Override
+        public String getName() {
+            return "failingHandler";
+        }
+
+        @Override
+        public void beforeStart() throws PersistenceException {
+            throw new PersistenceException();
+        }
+
+        @Override
+        public void start() throws PersistenceException {
+            throw new PersistenceException();
+        }
+
+        @Override
+        public void recordQuery(Query q) { }
+
+        @Override
+        public void beforeStop() { }
+
+        @Override
+        public void stop() { }
+    };
+
+
+
+}

--- a/rre-core/src/test/java/io/sease/rre/persistence/impl/JsonPersistenceHandlerTest.java
+++ b/rre-core/src/test/java/io/sease/rre/persistence/impl/JsonPersistenceHandlerTest.java
@@ -68,6 +68,19 @@ public class JsonPersistenceHandlerTest {
     }
 
     @Test
+    public void beforeStartPasses_whenDestinationDirNotExist() throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonPersistenceHandler.DESTINATION_FILE_CONFIGKEY, folder.getRoot().getAbsolutePath() + "/target/rre/evaluation.json");
+        handler.configure(HANDLER_NAME, config);
+
+        handler.beforeStart();
+
+        File target = new File(folder.getRoot(), "target/rre/evaluation.json");
+        assertTrue(target.exists());
+        assertTrue(target.canWrite());
+    }
+
+    @Test
     public void beforeStop_handlesEmptyQueryList() throws Exception {
         File outFile = folder.newFile();
         Map<String, Object> config = new HashMap<>();

--- a/rre-core/src/test/java/io/sease/rre/persistence/impl/JsonPersistenceHandlerTest.java
+++ b/rre-core/src/test/java/io/sease/rre/persistence/impl/JsonPersistenceHandlerTest.java
@@ -1,0 +1,83 @@
+package io.sease.rre.persistence.impl;
+
+import io.sease.rre.persistence.PersistenceException;
+import io.sease.rre.persistence.PersistenceHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for the JSON PersistenceHandler implementation.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public class JsonPersistenceHandlerTest {
+
+    private static final String HANDLER_NAME = "jsonTest";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private PersistenceHandler handler;
+
+    @Before
+    public void setupHandler() {
+        this.handler = new JsonPersistenceHandler();
+    }
+
+    @After
+    public void tearDownHandler() {
+        this.handler = null;
+    }
+
+    @Test
+    public void beforeStartThrowsException_whenFileCannotBeDeleted() throws Exception {
+        File outFile = folder.newFile();
+        outFile.setReadOnly();
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonPersistenceHandler.DESTINATION_FILE_CONFIGKEY, outFile.getAbsolutePath());
+        handler.configure(HANDLER_NAME, config);
+
+        try {
+            handler.beforeStart();
+            fail("Expected PersistenceException");
+        } catch (PersistenceException e) {
+            // Expected behaviour
+        }
+    }
+
+    @Test
+    public void beforeStartPasses_whenFileExists() throws Exception {
+        File outFile = folder.newFile();
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonPersistenceHandler.DESTINATION_FILE_CONFIGKEY, outFile.getAbsolutePath());
+        handler.configure(HANDLER_NAME, config);
+
+        handler.beforeStart();
+    }
+
+    @Test
+    public void beforeStop_handlesEmptyQueryList() throws Exception {
+        File outFile = folder.newFile();
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonPersistenceHandler.DESTINATION_FILE_CONFIGKEY, outFile.getAbsolutePath());
+        config.put(JsonPersistenceHandler.PRETTY_CONFIGKEY, true);
+        handler.configure(HANDLER_NAME, config);
+
+        handler.beforeStop();
+
+        assertTrue(outFile.exists());
+        assertTrue(outFile.length() != 0);
+    }
+}

--- a/rre-maven-archetype/rre-maven-solr-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/rre-maven-archetype/rre-maven-solr-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,6 +5,17 @@
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
     <packaging>pom</packaging>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <pluginRepositories>
+       <pluginRepository>
+          <id>sease</id>
+          <url>https://raw.github.com/SeaseLtd/rated-ranking-evaluator/mvn-repo</url>
+       </pluginRepository>
+    </pluginRepositories>         
     <build>
         <plugins>
             <plugin>

--- a/rre-maven-plugin/pom.xml
+++ b/rre-maven-plugin/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
@@ -94,7 +94,8 @@ public class RREvaluateMojo extends AbstractMojo {
                     metrics,
                     fields.split(","),
                     exclude,
-                    include);
+                    include,
+                    persistence);
 
             final Map<String, Object> configuration = new HashMap<>();
             configuration.put("path.home", "/tmp");

--- a/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
@@ -1,8 +1,6 @@
 package io.sease.rre.maven.plugin.elasticsearch;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sease.rre.core.Engine;
-import io.sease.rre.core.domain.Evaluation;
 import io.sease.rre.persistence.PersistenceConfiguration;
 import io.sease.rre.search.api.SearchPlatform;
 import io.sease.rre.search.api.impl.Elasticsearch;
@@ -19,8 +17,6 @@ import java.net.URLClassLoader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.Optional.ofNullable;
 
 /**
  * RREvalutation Mojo (Apache Solr binding).
@@ -102,28 +98,14 @@ public class RREvaluateMojo extends AbstractMojo {
             configuration.put("network.host", port);
             configuration.put("plugins", plugins);
 
-            write(engine.evaluate(configuration));
+            engine.evaluate(configuration);
         } catch (final IOException exception) {
             throw new MojoExecutionException(exception.getMessage(), exception);
         }
     }
 
-    /**
-     * Writes out the evaluation result.
-     *
-     * @param evaluation the evaluation result.
-     * @throws IOException in case of I/O failure.
-     */
-    private void write(final Evaluation evaluation) throws IOException {
-        final File outputFolder = new File("target/rre");
-        outputFolder.mkdirs();
-
-        final ObjectMapper mapper = new ObjectMapper();
-        mapper.writerWithDefaultPrettyPrinter().writeValue(new File(outputFolder, "evaluation.json"), evaluation);
-    }
-
+    // Used by unit test
     PersistenceConfiguration getPersistence() {
         return persistence;
-//        return ofNullable(persistence).orElse(PersistenceConfiguration.defaultConfiguration());
     }
 }

--- a/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
@@ -3,6 +3,7 @@ package io.sease.rre.maven.plugin.elasticsearch;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sease.rre.core.Engine;
 import io.sease.rre.core.domain.Evaluation;
+import io.sease.rre.persistence.PersistenceConfiguration;
 import io.sease.rre.search.api.SearchPlatform;
 import io.sease.rre.search.api.impl.Elasticsearch;
 import org.apache.maven.plugin.AbstractMojo;
@@ -18,6 +19,8 @@ import java.net.URLClassLoader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * RREvalutation Mojo (Apache Solr binding).
@@ -60,6 +63,9 @@ public class RREvaluateMojo extends AbstractMojo {
 
     @Parameter(name = "port", defaultValue = "9200")
     private int port;
+
+    @Parameter(name = "persistence")
+    private PersistenceConfiguration persistence = PersistenceConfiguration.DEFAULT_CONFIG;
 
     @Override
     public void execute() throws MojoExecutionException {
@@ -113,5 +119,10 @@ public class RREvaluateMojo extends AbstractMojo {
 
         final ObjectMapper mapper = new ObjectMapper();
         mapper.writerWithDefaultPrettyPrinter().writeValue(new File(outputFolder, "evaluation.json"), evaluation);
+    }
+
+    PersistenceConfiguration getPersistence() {
+        return persistence;
+//        return ofNullable(persistence).orElse(PersistenceConfiguration.defaultConfiguration());
     }
 }

--- a/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/test/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojoTest.java
+++ b/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/test/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojoTest.java
@@ -1,0 +1,61 @@
+package io.sease.rre.maven.plugin.elasticsearch;
+
+import io.sease.rre.persistence.PersistenceConfiguration;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Basic configuration tests for the ES Evaluate plugin.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public class RREvaluateMojoTest {
+
+    @Rule
+    public MojoRule rule = new MojoRule()
+    {
+        @Override
+        protected void before() throws Throwable
+        {
+        }
+
+        @Override
+        protected void after()
+        {
+        }
+    };
+
+    @Test
+    public void testBuildsDefaultPersistenceConfig_whenNoPersistenceConfigInPom() throws Exception {
+        Mojo mojo = rule.lookupMojo("evaluate", "src/test/resources/persistence/no_persistence_pom.xml");
+        assertNotNull(mojo);
+
+        RREvaluateMojo rreMojo = (RREvaluateMojo) mojo;
+        PersistenceConfiguration persist = rreMojo.getPersistence();
+        assertNotNull(persist);
+        assertFalse(persist.isUseTimestampAsVersion());
+        assertEquals(persist.getHandlers().size(), 1);
+        assertTrue(persist.getHandlers().containsKey("json"));
+        assertTrue(persist.getHandlerConfiguration().containsKey("json"));
+    }
+
+    @Test
+    public void testBuildsCorrectPersistenceConfig_whenPersistenceConfigInPom() throws Exception {
+        Mojo mojo = rule.lookupMojo("evaluate", "src/test/resources/persistence/persistence_pom.xml");
+        assertNotNull(mojo);
+
+        RREvaluateMojo rreMojo = (RREvaluateMojo) mojo;
+        PersistenceConfiguration persist = rreMojo.getPersistence();
+        assertNotNull(persist);
+        assertTrue(persist.isUseTimestampAsVersion());
+        assertEquals(persist.getHandlers().size(), 1);
+        assertTrue(persist.getHandlers().containsKey("testJson"));
+        assertTrue(persist.getHandlerConfiguration().containsKey("testJson"));
+        assertNotNull(persist.getHandlerConfiguration().get("testJson"));
+        assertEquals(persist.getHandlerConfiguration().get("testJson").get("destinationFile"), "blah.txt");
+    }
+}

--- a/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/test/resources/persistence/no_persistence_pom.xml
+++ b/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/test/resources/persistence/no_persistence_pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.sease</groupId>
+    <artifactId>rre-maven-elasticsearch-plugin</artifactId>
+    <version>6.3.2</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>sease</id>
+            <url>https://raw.github.com/SeaseLtd/rated-ranking-evaluator/mvn-repo</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.sease</groupId>
+                <artifactId>rre-maven-elasticsearch-plugin</artifactId>
+                <version>${esVersion}</version>
+                <!-- the configuration below is provided just for example, as it perfectly matches default values -->
+                <configuration>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>search-quality-evaluation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>evaluate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/test/resources/persistence/persistence_pom.xml
+++ b/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/test/resources/persistence/persistence_pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.sease</groupId>
+    <artifactId>rre-maven-elasticsearch-plugin</artifactId>
+    <version>6.3.2</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>sease</id>
+            <url>https://raw.github.com/SeaseLtd/rated-ranking-evaluator/mvn-repo</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.sease</groupId>
+                <artifactId>rre-maven-elasticsearch-plugin</artifactId>
+                <version>${esVersion}</version>
+                <configuration>
+                    <persistence>
+                        <useTimestampAsVersion>true</useTimestampAsVersion>
+                        <handlers>
+                            <testJson>io.sease.rre.persistence.impl.JsonPersistenceHandler</testJson>
+                        </handlers>
+                        <handlerConfiguration>
+                            <testJson>
+                                <destinationFile>blah.txt</destinationFile>
+                            </testJson>
+                        </handlerConfiguration>
+                    </persistence>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>search-quality-evaluation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>evaluate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/rre-maven-plugin/rre-maven-report-plugin/src/main/java/io/sease/rre/maven/plugin/report/RREMavenReport.java
+++ b/rre-maven-plugin/rre-maven-report-plugin/src/main/java/io/sease/rre/maven/plugin/report/RREMavenReport.java
@@ -2,11 +2,11 @@ package io.sease.rre.maven.plugin.report;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sease.rre.maven.plugin.report.domain.EvaluationMetadata;
 import io.sease.rre.maven.plugin.report.formats.OutputFormat;
 import io.sease.rre.maven.plugin.report.formats.impl.RREOutputFormat;
 import io.sease.rre.maven.plugin.report.formats.impl.SpreadsheetOutputFormat;
+import io.sease.rre.persistence.impl.JsonPersistenceHandler;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.reporting.AbstractMavenReport;
@@ -34,6 +34,9 @@ public class RREMavenReport extends AbstractMavenReport {
 
     @Parameter(name = "endpoint", defaultValue = "http://127.0.0.1:8080")
     String endpoint;
+
+    @Parameter(name="evaluationFile", defaultValue = JsonPersistenceHandler.DEFAULT_OUTPUT_FILE)
+    String evaluationFile;
 
     private Map<String, OutputFormat> formatters = new HashMap<>();
 
@@ -131,7 +134,7 @@ public class RREMavenReport extends AbstractMavenReport {
      * @return a file reference to the evaluation output.
      */
     File evaluationOutputFile() {
-        final File file = new File("target/rre/evaluation.json");
+        final File file = new File(evaluationFile);
         if (!file.canRead()) {
             throw new RuntimeException("Unable to read RRE evaluation output file. Are you sure RRE executed successfully?");
         }

--- a/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
@@ -1,8 +1,6 @@
 package io.sease.rre.maven.plugin.solr;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sease.rre.core.Engine;
-import io.sease.rre.core.domain.Evaluation;
 import io.sease.rre.persistence.PersistenceConfiguration;
 import io.sease.rre.search.api.SearchPlatform;
 import io.sease.rre.search.api.impl.ApacheSolr;
@@ -12,7 +10,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -72,23 +69,9 @@ public class RREvaluateMojo extends AbstractMojo {
             final Map<String, Object> configuration = new HashMap<>();
             configuration.put("solr.home", "/tmp");
 
-            write(engine.evaluate(configuration));
+            engine.evaluate(configuration);
         } catch (final IOException exception) {
             throw new MojoExecutionException(exception.getMessage(), exception);
         }
-    }
-
-    /**
-     * Writes out the evaluation result.
-     *
-     * @param evaluation the evaluation result.
-     * @throws IOException in case of I/O failure.
-     */
-    private void write(final Evaluation evaluation) throws IOException {
-        final File outputFolder = new File("target/rre");
-        outputFolder.mkdirs();
-
-        final ObjectMapper mapper = new ObjectMapper();
-        mapper.writerWithDefaultPrettyPrinter().writeValue(new File(outputFolder, "evaluation.json"), evaluation);
     }
 }

--- a/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
@@ -3,6 +3,7 @@ package io.sease.rre.maven.plugin.solr;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sease.rre.core.Engine;
 import io.sease.rre.core.domain.Evaluation;
+import io.sease.rre.persistence.PersistenceConfiguration;
 import io.sease.rre.search.api.SearchPlatform;
 import io.sease.rre.search.api.impl.ApacheSolr;
 import org.apache.maven.plugin.AbstractMojo;
@@ -50,6 +51,9 @@ public class RREvaluateMojo extends AbstractMojo {
     @Parameter(name = "exclude")
     private List<String> exclude;
 
+    @Parameter(name = "persistence")
+    private PersistenceConfiguration persistence = PersistenceConfiguration.DEFAULT_CONFIG;
+
     @Override
     public void execute() throws MojoExecutionException {
         try (final SearchPlatform platform = new ApacheSolr()) {
@@ -62,7 +66,8 @@ public class RREvaluateMojo extends AbstractMojo {
                     metrics,
                     fields.split(","),
                     exclude,
-                    include);
+                    include,
+                    persistence);
 
             final Map<String, Object> configuration = new HashMap<>();
             configuration.put("solr.home", "/tmp");


### PR DESCRIPTION
This implements a base persistence framework in rre-core, as per issue #54.

It includes a JsonPersistenceHandler implementation, which is used by default and produces the same output content as the current version (although not prettified). There are some configuration options available, and I have updated the rre-maven-report-plugin to allow it to be used with non-default configuration.