### PR TITLE
Allow parameters to be passed to generic metrics

### DIFF
--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/MetricClassManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/MetricClassManager.java
@@ -1,0 +1,35 @@
+package io.sease.rre.core.domain.metrics;
+
+import java.util.Collection;
+
+/**
+ * A MetricClassManager is used to supply the metrics available to the
+ * evaluations.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public interface MetricClassManager {
+
+    /**
+     * Retrieve the list of metrics available to each evaluation. These may
+     * be class names, or other strings which can be used to reference a
+     * metric that requires further configuration - for example, multiple
+     * instances of PrecisionAtK with different values for K.
+     *
+     * @return the available metrics.
+     */
+    Collection<String> getMetrics();
+
+    /**
+     * Instantiate a metric, using the name given in the {@link #getMetrics()}
+     * list, and initialising with any additional configuration detail
+     * available.
+     *
+     * @param metricName the name of the metric to be instantiated.
+     * @return an instance of a {@link Metric}.
+     * @throws IllegalArgumentException if the metric is not in the configured
+     *                                  list, or the class cannot be found.
+     * @throws InstantiationException   if the metric cannot be instantiated.
+     */
+   Metric instantiateMetric(String metricName) throws IllegalArgumentException, InstantiationException;
+}

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/ParameterizedMetricClassManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/ParameterizedMetricClassManager.java
@@ -1,0 +1,125 @@
+package io.sease.rre.core.domain.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * A MetricClassManager implementation which allows both simple
+ * (non-configurable) and configurable metrics to be constructed using
+ * supplied parameters.
+ * <p>
+ * The parameterized metrics should have a constructor with {@code JsonProperty}
+ * annotations indicating how the configuration should be used.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public class ParameterizedMetricClassManager extends SimpleMetricClassManager implements MetricClassManager {
+
+    private final static Logger LOGGER = LogManager.getLogger(ParameterizedMetricClassManager.class);
+
+    private static final String METRIC_CLASS_KEY = "class";
+
+    private final Map<String, Map<String, Object>> metricConfiguration;
+    private final Map<String, String> metricClasses;
+
+    public ParameterizedMetricClassManager(Collection<String> metricNames, Map<String, Map> metricConfiguration) {
+        super(metricNames);
+        this.metricClasses = extractParameterizedClassNames(metricConfiguration);
+        this.metricConfiguration = convertMetricConfiguration(metricConfiguration);
+        addMetricNames(metricClasses.keySet());
+    }
+
+    /**
+     * Extract the class names for each parameterized metric from the incoming map.
+     * Doubles up as a check that the parameterized configuration contains a classname
+     * for each required metric.
+     *
+     * @param incoming the incoming metric configurations.
+     * @return a map of String:String, containing the class for each parameterized
+     * metric we need to build.
+     * @throws IllegalArgumentException if any of the configurations do not have a
+     *                                  class property.
+     */
+    private Map<String, String> extractParameterizedClassNames(final Map<String, Map> incoming) throws IllegalArgumentException {
+        final Map<String, String> classNames;
+        if (incoming == null) {
+            classNames = Collections.emptyMap();
+        } else {
+            classNames = new HashMap<>();
+            incoming.forEach((k, configMap) -> {
+                if (!configMap.containsKey(METRIC_CLASS_KEY)) {
+                    throw new IllegalArgumentException("No class set for metric " + k);
+                } else {
+                    classNames.put(k, (String) configMap.get(METRIC_CLASS_KEY));
+                }
+            });
+        }
+        return classNames;
+    }
+
+    /**
+     * Extract the configuration properties for each parameterized metric from
+     * the incoming map, stripping out the implementation class name as we go,
+     * and convert them to a map of String:Object items.
+     *
+     * @param incoming the incoming metric configurations.
+     * @return an equivalent map containing configuration that can be used to
+     * construct a Metric without stripping any content.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Map<String, Object>> convertMetricConfiguration(final Map<String, Map> incoming) {
+        final Map<String, Map<String, Object>> configurations;
+        if (incoming == null) {
+            configurations = Collections.emptyMap();
+        } else {
+            configurations = new HashMap<>();
+            incoming.forEach((n, m) -> {
+                Map<String, Object> config = new HashMap<>();
+                m.forEach((k, v) -> {
+                    if (!k.equals(METRIC_CLASS_KEY)) {
+                        config.put((String) k, v);
+                    }
+                });
+                configurations.put(n, config);
+            });
+        }
+        return configurations;
+    }
+
+    @Override
+    public Metric instantiateMetric(String metricName) throws IllegalArgumentException, InstantiationException {
+        final Metric metric;
+        if (!metricConfiguration.containsKey(metricName)) {
+            // Simple metric - use superclass to build
+            metric = super.instantiateMetric(metricName);
+        } else {
+            // Parameterized metric - firstly identify the class
+            final String className = metricClasses.get(metricName);
+            final Class<? extends Metric> klazz = findMetricClass(className);
+            metric = instantiateClassWithConfiguration(klazz, metricConfiguration.get(metricName));
+        }
+        return metric;
+    }
+
+    private Metric instantiateClassWithConfiguration(final Class<? extends Metric> metricClass,
+                                                     final Map<String, Object> metricConfiguration) throws InstantiationException {
+        final Metric m;
+        try {
+            /* We build by converting the config to JSON, then constructing the
+             * required class from the JSON string - this is *much* easier than
+             * trying to find the correct constructor, etc., ourselves. */
+            final ObjectMapper mapper = new ObjectMapper();
+            final String configJson = mapper.writeValueAsString(metricConfiguration);
+            m = mapper.readValue(configJson, metricClass);
+        } catch (IOException e) {
+            // Either the map could not be serialized to JSON, or the JSON has properties that don't match the constructor
+            LOGGER.error("Caught IO exception instantiating configured class {} :: {}", metricClass.getName(), e.getMessage());
+            throw new InstantiationException(e.getMessage());
+        }
+        return m;
+    }
+}

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/SimpleMetricClassManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/SimpleMetricClassManager.java
@@ -1,0 +1,58 @@
+package io.sease.rre.core.domain.metrics;
+
+import io.sease.rre.Func;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manager class for instantiating metrics configured for evaluation. This
+ * implementation only handles metrics defined by their class names, and
+ * not requiring any additional configuration - ie. those with zero-argument
+ * constructors.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public class SimpleMetricClassManager implements MetricClassManager {
+
+    private final Collection<String> metricNames;
+    private final Map<String, Class<? extends Metric>> metricClasses = new HashMap<>();
+
+    public SimpleMetricClassManager(Collection<String> metricClasses) {
+        this.metricNames = metricClasses;
+    }
+
+    @Override
+    public Collection<String> getMetrics() {
+        return metricNames;
+    }
+
+    @Override
+    public Metric instantiateMetric(String metricName) throws IllegalArgumentException, InstantiationException {
+        final Class<? extends Metric> klazz = findMetricClass(metricName);
+        return instantiateMetricClass(klazz);
+    }
+
+    private Class<? extends Metric> findMetricClass(String metricName) throws IllegalArgumentException {
+        final Class<? extends Metric> klazz;
+        if (metricClasses.containsKey(metricName)) {
+            klazz = metricClasses.get(metricName);
+        } else {
+            klazz = Func.newMetricDefinition(metricName);
+            metricClasses.put(metricName, klazz);
+        }
+
+        return klazz;
+    }
+
+    private Metric instantiateMetricClass(Class<? extends Metric> metricClass) throws InstantiationException {
+        try {
+            return metricClass.newInstance();
+        } catch (InstantiationException e) {
+            throw e;
+        } catch (IllegalAccessException e) {
+            throw new InstantiationException("Illegal access of class " + metricClass);
+        }
+    }
+}

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/SimpleMetricClassManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/SimpleMetricClassManager.java
@@ -2,9 +2,7 @@ package io.sease.rre.core.domain.metrics;
 
 import io.sease.rre.Func;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Manager class for instantiating metrics configured for evaluation. This
@@ -20,12 +18,12 @@ public class SimpleMetricClassManager implements MetricClassManager {
     private final Map<String, Class<? extends Metric>> metricClasses = new HashMap<>();
 
     public SimpleMetricClassManager(Collection<String> metricClasses) {
-        this.metricNames = metricClasses;
+        this.metricNames = new ArrayList<>(metricClasses);
     }
 
     @Override
     public Collection<String> getMetrics() {
-        return metricNames;
+        return Collections.unmodifiableCollection(metricNames);
     }
 
     @Override
@@ -34,7 +32,7 @@ public class SimpleMetricClassManager implements MetricClassManager {
         return instantiateMetricClass(klazz);
     }
 
-    private Class<? extends Metric> findMetricClass(String metricName) throws IllegalArgumentException {
+    Class<? extends Metric> findMetricClass(String metricName) throws IllegalArgumentException {
         final Class<? extends Metric> klazz;
         if (metricClasses.containsKey(metricName)) {
             klazz = metricClasses.get(metricName);
@@ -49,10 +47,12 @@ public class SimpleMetricClassManager implements MetricClassManager {
     private Metric instantiateMetricClass(Class<? extends Metric> metricClass) throws InstantiationException {
         try {
             return metricClass.newInstance();
-        } catch (InstantiationException e) {
-            throw e;
         } catch (IllegalAccessException e) {
             throw new InstantiationException("Illegal access of class " + metricClass);
         }
+    }
+
+    void addMetricNames(Collection<String> names) {
+        metricNames.addAll(names);
     }
 }

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/PrecisionAtK.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/PrecisionAtK.java
@@ -1,5 +1,6 @@
 package io.sease.rre.core.domain.metrics.impl;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.sease.rre.core.domain.metrics.Metric;
 import io.sease.rre.core.domain.metrics.ValueFactory;
 
@@ -23,7 +24,7 @@ public class PrecisionAtK extends Metric {
      *
      * @param k the precision bound.
      */
-    PrecisionAtK(final int k) {
+    PrecisionAtK(@JsonProperty("k") final int k) {
         super("P@" + k);
         this.k = k;
     }

--- a/rre-core/src/test/java/io/sease/rre/core/domain/metrics/ParameterizedMetricClassManagerTest.java
+++ b/rre-core/src/test/java/io/sease/rre/core/domain/metrics/ParameterizedMetricClassManagerTest.java
@@ -1,0 +1,83 @@
+package io.sease.rre.core.domain.metrics;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for the ParameterizedMetricClassManager.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+@SuppressWarnings("unchecked")
+public class ParameterizedMetricClassManagerTest {
+
+    private static final String[] METRICS = new String[]{
+            "io.sease.rre.core.domain.metrics.impl.PrecisionAtOne",
+            "non.existent.DummyMetric",
+            "io.sease.rre.core.domain.metrics.impl.PrecisionAtK"
+    };
+
+    private MetricClassManager manager = new ParameterizedMetricClassManager(Arrays.asList(METRICS), null);
+
+    @Test
+    public void canInstantiateSimpleMetric() throws Exception {
+        Metric m = manager.instantiateMetric("io.sease.rre.core.domain.metrics.impl.PrecisionAtOne");
+
+        assertNotNull(m);
+        assertTrue(m instanceof io.sease.rre.core.domain.metrics.impl.PrecisionAtOne);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsExceptionForUndefinedMetric() throws Exception {
+        manager.instantiateMetric("blah.blah.NoMetric");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsExceptionForNonExistentMetric() throws Exception {
+        manager.instantiateMetric("non.existent.DummyMetric");
+    }
+
+    @Test(expected = InstantiationException.class)
+    public void throwsExceptionForMetricRequiringConfig_whenNoConfigSupplied() throws Exception {
+        manager.instantiateMetric("io.sease.rre.core.domain.metrics.impl.PrecisionAtK");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructionFailsWhenClassDetailsMissing() throws Exception {
+        final Map precisionAtFiveConfig = new HashMap();
+        final Map<String, Map> metricConfiguration = new HashMap<>();
+        metricConfiguration.put("pAt5", precisionAtFiveConfig);
+        new ParameterizedMetricClassManager(Arrays.asList(METRICS), metricConfiguration);
+    }
+
+    @Test(expected = InstantiationException.class)
+    public void throwsExceptionForParameterizedMetric_whenConfigIsWrong() throws Exception {
+        final Map precisionAtFiveConfig = new HashMap();
+        precisionAtFiveConfig.put("class", "io.sease.rre.core.domain.metrics.impl.PrecisionAtK");
+        precisionAtFiveConfig.put("v", 5);
+        final Map<String, Map> metricConfiguration = new HashMap<>();
+        metricConfiguration.put("pAt5", precisionAtFiveConfig);
+        final MetricClassManager manager = new ParameterizedMetricClassManager(Arrays.asList(METRICS), metricConfiguration);
+        manager.instantiateMetric("pAt5");
+    }
+
+    @Test
+    public void canInstantiateParameterizedMetric() throws Exception {
+        final Map precisionAtFiveConfig = new HashMap();
+        precisionAtFiveConfig.put("class", "io.sease.rre.core.domain.metrics.impl.PrecisionAtK");
+        precisionAtFiveConfig.put("k", 5);
+        final Map<String, Map> metricConfiguration = new HashMap<>();
+        metricConfiguration.put("pAt5", precisionAtFiveConfig);
+        final MetricClassManager manager = new ParameterizedMetricClassManager(Arrays.asList(METRICS), metricConfiguration);
+        Metric m = manager.instantiateMetric("pAt5");
+
+        assertNotNull(m);
+        assertTrue(m instanceof io.sease.rre.core.domain.metrics.impl.PrecisionAtK);
+        assertEquals("P@5", m.getName());
+    }
+}

--- a/rre-core/src/test/java/io/sease/rre/core/domain/metrics/SimpleMetricClassManagerTest.java
+++ b/rre-core/src/test/java/io/sease/rre/core/domain/metrics/SimpleMetricClassManagerTest.java
@@ -1,0 +1,47 @@
+package io.sease.rre.core.domain.metrics;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the SimpleMetricClassManager class.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public class SimpleMetricClassManagerTest {
+
+    private static final String[] METRICS = new String[]{
+            "io.sease.rre.core.domain.metrics.impl.PrecisionAtOne",
+            "non.existent.DummyMetric",
+            "io.sease.rre.core.domain.metrics.impl.PrecisionAtK"
+    };
+
+    private MetricClassManager manager = new SimpleMetricClassManager(Arrays.asList(METRICS));
+
+    @Test
+    public void canInstantiateSimpleMetric() throws Exception {
+        Metric m = manager.instantiateMetric("io.sease.rre.core.domain.metrics.impl.PrecisionAtOne");
+
+        assertNotNull(m);
+        assertTrue(m instanceof io.sease.rre.core.domain.metrics.impl.PrecisionAtOne);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsExceptionForUndefinedMetric() throws Exception {
+        manager.instantiateMetric("blah.blah.NoMetric");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsExceptionForNonExistentMetric() throws Exception {
+        manager.instantiateMetric("non.existent.DummyMetric");
+    }
+
+    @Test(expected = InstantiationException.class)
+    public void throwsExceptionForMetricRequiringConfig() throws Exception {
+        manager.instantiateMetric("io.sease.rre.core.domain.metrics.impl.PrecisionAtK");
+    }
+}

--- a/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
@@ -1,6 +1,8 @@
 package io.sease.rre.maven.plugin.elasticsearch;
 
 import io.sease.rre.core.Engine;
+import io.sease.rre.core.domain.metrics.MetricClassManager;
+import io.sease.rre.core.domain.metrics.ParameterizedMetricClassManager;
 import io.sease.rre.core.domain.metrics.SimpleMetricClassManager;
 import io.sease.rre.persistence.PersistenceConfiguration;
 import io.sease.rre.search.api.SearchPlatform;
@@ -55,6 +57,9 @@ public class RREvaluateMojo extends AbstractMojo {
     @Parameter(name = "metrics", defaultValue = "io.sease.rre.core.domain.metrics.impl.PrecisionAtOne,io.sease.rre.core.domain.metrics.impl.PrecisionAtTwo,io.sease.rre.core.domain.metrics.impl.PrecisionAtThree,io.sease.rre.core.domain.metrics.impl.PrecisionAtTen")
     private List<String> metrics;
 
+    @Parameter(name = "parameterizedMetrics")
+    private Map<String, Map> parameterizedMetrics;
+
     @Parameter(name = "plugins")
     private List<String> plugins;
 
@@ -91,13 +96,15 @@ public class RREvaluateMojo extends AbstractMojo {
                             Thread.currentThread().getContextClassLoader()));
 
         try (final SearchPlatform platform = new Elasticsearch()) {
+            final MetricClassManager metricClassManager =
+                    parameterizedMetrics == null ? new SimpleMetricClassManager(metrics) : new ParameterizedMetricClassManager(metrics, parameterizedMetrics);
             final Engine engine = new Engine(
                     platform,
                     configurationsFolder,
                     corporaFolder,
                     ratingsFolder,
                     templatesFolder,
-                    new SimpleMetricClassManager(metrics),
+                    metricClassManager,
                     fields.split(","),
                     exclude,
                     include,

--- a/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/elasticsearch/RREvaluateMojo.java
@@ -1,6 +1,7 @@
 package io.sease.rre.maven.plugin.elasticsearch;
 
 import io.sease.rre.core.Engine;
+import io.sease.rre.core.domain.metrics.SimpleMetricClassManager;
 import io.sease.rre.persistence.PersistenceConfiguration;
 import io.sease.rre.search.api.SearchPlatform;
 import io.sease.rre.search.api.impl.Elasticsearch;
@@ -96,7 +97,7 @@ public class RREvaluateMojo extends AbstractMojo {
                     corporaFolder,
                     ratingsFolder,
                     templatesFolder,
-                    metrics,
+                    new SimpleMetricClassManager(metrics),
                     fields.split(","),
                     exclude,
                     include,

--- a/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
@@ -3,6 +3,7 @@ package io.sease.rre.maven.plugin.external.elasticsearch;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sease.rre.core.Engine;
 import io.sease.rre.core.domain.Evaluation;
+import io.sease.rre.core.domain.metrics.SimpleMetricClassManager;
 import io.sease.rre.persistence.PersistenceConfiguration;
 import io.sease.rre.search.api.SearchPlatform;
 import io.sease.rre.search.api.impl.ExternalElasticsearch;
@@ -80,7 +81,7 @@ public class RREvaluateMojo extends AbstractMojo {
                     null,
                     ratingsFolder,
                     templatesFolder,
-                    metrics,
+                    new SimpleMetricClassManager(metrics),
                     fields.split(","),
                     exclude,
                     include,

--- a/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-external-elasticsearch-plugin/src/main/java/io/sease/rre/maven/plugin/external/elasticsearch/RREvaluateMojo.java
@@ -3,6 +3,8 @@ package io.sease.rre.maven.plugin.external.elasticsearch;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sease.rre.core.Engine;
 import io.sease.rre.core.domain.Evaluation;
+import io.sease.rre.core.domain.metrics.MetricClassManager;
+import io.sease.rre.core.domain.metrics.ParameterizedMetricClassManager;
 import io.sease.rre.core.domain.metrics.SimpleMetricClassManager;
 import io.sease.rre.persistence.PersistenceConfiguration;
 import io.sease.rre.search.api.SearchPlatform;
@@ -45,6 +47,9 @@ public class RREvaluateMojo extends AbstractMojo {
     @Parameter(name = "metrics", defaultValue = "io.sease.rre.core.domain.metrics.impl.PrecisionAtOne,io.sease.rre.core.domain.metrics.impl.PrecisionAtTwo,io.sease.rre.core.domain.metrics.impl.PrecisionAtThree,io.sease.rre.core.domain.metrics.impl.PrecisionAtTen")
     private List<String> metrics;
 
+    @Parameter(name = "parameterizedMetrics")
+    private Map<String, Map> parameterizedMetrics;
+
     @Parameter(name = "fields", defaultValue = "")
     private String fields;
 
@@ -75,13 +80,15 @@ public class RREvaluateMojo extends AbstractMojo {
                                 Thread.currentThread().getContextClassLoader()));
 
         try (final SearchPlatform platform = new ExternalElasticsearch()) {
+            final MetricClassManager metricClassManager =
+                    parameterizedMetrics == null ? new SimpleMetricClassManager(metrics) : new ParameterizedMetricClassManager(metrics, parameterizedMetrics);
             final Engine engine = new Engine(
                     platform,
                     configurationsFolder,
                     null,
                     ratingsFolder,
                     templatesFolder,
-                    new SimpleMetricClassManager(metrics),
+                    metricClassManager,
                     fields.split(","),
                     exclude,
                     include,

--- a/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
@@ -1,6 +1,8 @@
 package io.sease.rre.maven.plugin.solr;
 
 import io.sease.rre.core.Engine;
+import io.sease.rre.core.domain.metrics.MetricClassManager;
+import io.sease.rre.core.domain.metrics.ParameterizedMetricClassManager;
 import io.sease.rre.core.domain.metrics.SimpleMetricClassManager;
 import io.sease.rre.persistence.PersistenceConfiguration;
 import io.sease.rre.search.api.SearchPlatform;
@@ -49,6 +51,9 @@ public class RREvaluateMojo extends AbstractMojo {
     @Parameter(name = "metrics", defaultValue = "io.sease.rre.core.domain.metrics.impl.PrecisionAtOne,io.sease.rre.core.domain.metrics.impl.PrecisionAtTwo,io.sease.rre.core.domain.metrics.impl.PrecisionAtThree,io.sease.rre.core.domain.metrics.impl.PrecisionAtTen")
     private List<String> metrics;
 
+    @Parameter(name = "parameterizedMetrics")
+    private Map<String, Map> parameterizedMetrics;
+
     @Parameter(name = "fields", defaultValue = "*,score")
     private String fields;
 
@@ -64,13 +69,15 @@ public class RREvaluateMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException {
         try (final SearchPlatform platform = new ApacheSolr()) {
+            final MetricClassManager metricClassManager =
+                    parameterizedMetrics == null ? new SimpleMetricClassManager(metrics) : new ParameterizedMetricClassManager(metrics, parameterizedMetrics);
             final Engine engine = new Engine(
                     platform,
                     configurationsFolder,
                     corporaFolder,
                     ratingsFolder,
                     templatesFolder,
-                    new SimpleMetricClassManager(metrics),
+                    metricClassManager,
                     fields.split(","),
                     exclude,
                     include,

--- a/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
+++ b/rre-maven-plugin/rre-maven-solr-plugin/src/main/java/io/sease/rre/maven/plugin/solr/RREvaluateMojo.java
@@ -1,6 +1,7 @@
 package io.sease.rre.maven.plugin.solr;
 
 import io.sease.rre.core.Engine;
+import io.sease.rre.core.domain.metrics.SimpleMetricClassManager;
 import io.sease.rre.persistence.PersistenceConfiguration;
 import io.sease.rre.search.api.SearchPlatform;
 import io.sease.rre.search.api.impl.ApacheSolr;
@@ -69,7 +70,7 @@ public class RREvaluateMojo extends AbstractMojo {
                     corporaFolder,
                     ratingsFolder,
                     templatesFolder,
-                    metrics,
+                    new SimpleMetricClassManager(metrics),
                     fields.split(","),
                     exclude,
                     include,

--- a/rre-search-platform/rre-search-platform-api/src/main/java/io/sease/rre/search/api/SearchPlatform.java
+++ b/rre-search-platform/rre-search-platform-api/src/main/java/io/sease/rre/search/api/SearchPlatform.java
@@ -50,6 +50,7 @@ public interface SearchPlatform extends Closeable {
      *
      * @param indexName the index name that holds the data.
      * @param query     the query.
+     * @param fields    the fields to return.
      * @param maxRows   the maximum number of rows that will be returned.
      * @return the response of the query execution.
      */
@@ -77,7 +78,7 @@ public interface SearchPlatform extends Closeable {
      * index?
      *
      * @param indexName the index name being processed.
-     * @param file the file to be tested.
+     * @param file      the file to be tested.
      * @return {@code true} if the file is a search platform config file or
      * directory.
      */


### PR DESCRIPTION
This PR adds the option to pass configuration parameters to generic metrics - for example, PrecisionAtK. This means that we don't need one class definition for every concrete implementation of the generic metrics.

It requires that the generic metric have a constructor with `@JsonProperty` annotations, matching up with the properties passed in the config - I've made this change in the PrecisionAtK class in the patch.

The configuration is passed from Maven via the pom.xml. In addition to the `metrics` block, there is a new, optional, `parameterizedMetrics` block, like so:

```
<metrics> ... metrics here </metrics>
<parameterizedMetrics>
  <metricName>  <!-- Can be anything, but must be unique -->
    <!-- Name of the metric class to instantiate -->
    <class>io.sease.rre.core.domain.metrics.impl.PrecisionAtK</class>
    <!-- Constructor parameters, matching @JsonProperty annotations -->
    <k>5</k>
  </metricName>
</parameterizedMetrics>
```

I hope this sounds sensible, and look forward to getting your feedback!