### PR TITLE
FMeasure and Recall at K

### DIFF
--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/FMeasureAtK.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/FMeasureAtK.java
@@ -1,0 +1,110 @@
+package io.sease.rre.core.domain.metrics.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.sease.rre.Calculator;
+import io.sease.rre.core.domain.metrics.Metric;
+import io.sease.rre.core.domain.metrics.ValueFactory;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The F-measure measures the effectiveness of retrieval with respect to a user who attaches (beta) times as much importance to recall as precision.
+ * In statistical analysis of binary classification, the F1 score (also F-score or F-measure) is a measure of a test's accuracy.
+ * It considers both the precision p and the recall r of the test to compute the score: p is the number of correct positive results
+ * divided by the number of all positive results returned by the classifier, and r is the number of correct positive results
+ * divided by the number of all relevant samples (all samples that should have been identified as positive).
+ *
+ * The F1 score is the harmonic average of the precision and recall, where an F1 score reaches its best value at 1
+ * (perfect precision and recall) and worst at 0.
+ *
+ * (Wikipedia)
+ *
+ * @author agazzarini
+ * @author worleydl 
+ */
+public class FMeasureAtK extends Metric {
+
+    private final BigDecimal beta;
+    private final int k;
+
+    final Metric precision;
+    final Metric recall;
+
+    /**
+     * Builds a new F-Measure/F-Score at K metric with the given beta factor.
+     *
+     * @param beta the balance factor between precision and recall.
+     * @param k the measure bound
+     */
+    public FMeasureAtK(@JsonProperty("beta") final float beta, @JsonProperty("k") final int k) {
+        super("F" + beta + "@" + k);
+        this.beta = BigDecimal.valueOf(beta).pow(2);
+        this.k = k;
+        
+        this.precision = new PrecisionAtK(k);
+        this.recall = new RecallAtK(k);
+    }
+
+    @Override
+    public ValueFactory createValueFactory(final String version) {
+        return new ValueFactory(this, version) {
+            @Override
+            public BigDecimal value() {
+                final BigDecimal betaPlusOne = Calculator.sum(BigDecimal.ONE, beta);
+
+                final BigDecimal p = precision.valueFactory(version).value();
+                final BigDecimal r = recall.valueFactory(version).value();
+
+                if (p.doubleValue() == 0 || r.doubleValue() == 0) return BigDecimal.ZERO;
+
+                final BigDecimal precisionTimesBeta = Calculator.multiply(p, beta);
+
+                final BigDecimal dividend = Calculator.multiply(p,r);
+                final BigDecimal divisor = Calculator.sum(precisionTimesBeta,r);
+
+                return Calculator.multiply(betaPlusOne, Calculator.divide(dividend, divisor));
+            }
+
+            @Override
+            public void setTotalHits(long totalHits, String version) {
+                precision.setTotalHits(totalHits, version);
+                recall.setTotalHits(totalHits, version);
+            }
+
+            @Override
+            public void collect(final Map<String, Object> hit, final int rank, final String version) {
+                precision.collect(hit, rank, version);
+                recall.collect(hit, rank, version);
+            }
+        };
+    }
+
+    @Override
+    public void setTotalHits(long totalHits, String version) {
+        super.setTotalHits(totalHits, version);
+    }
+
+    @Override
+    public void setRelevantDocuments(JsonNode relevantDocuments) {
+        super.setRelevantDocuments(relevantDocuments);
+        precision.setRelevantDocuments(relevantDocuments);
+        recall.setRelevantDocuments(relevantDocuments);
+    }
+
+    @Override
+    public void setVersions(List<String> versions) {
+        super.setVersions(versions);
+        precision.setVersions(versions);
+        recall.setVersions(versions);
+    }
+
+    @Override
+    public void setIdFieldName(String idFieldName) {
+        super.setIdFieldName(idFieldName);
+        precision.setIdFieldName(idFieldName);
+        recall.setIdFieldName(idFieldName);
+    }
+}

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/RecallAtK.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/RecallAtK.java
@@ -1,0 +1,53 @@
+package io.sease.rre.core.domain.metrics.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.sease.rre.core.domain.metrics.Metric;
+import io.sease.rre.core.domain.metrics.ValueFactory;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.sease.rre.Calculator.divide;
+
+/**
+ * Recall is the fraction of the documents that are relevant to the query that are successfully retrieved.
+ *
+ * @author agazzarini
+ * @author worleydl 
+ */
+public class RecallAtK extends Metric {
+    private final int k;
+
+    /**
+     * Builds a new Recall at K metric.
+     *
+     * @param k the recallbound
+     */
+    public RecallAtK(@JsonProperty("k") final int k) {
+        super("R@" + k);
+        this.k = k;
+    }
+
+    @Override
+    public ValueFactory createValueFactory(final String version) {
+        return new ValueFactory(this, version) {
+            final AtomicInteger relevantItemsFound = new AtomicInteger();
+
+            @Override
+            public void collect(final Map<String, Object> hit, final int rank, final String version) {
+                if (rank <= k && judgment(id(hit)).isPresent()){
+                    relevantItemsFound.incrementAndGet();
+                }
+            }
+
+            @Override
+            public BigDecimal value() {
+                if (relevantDocuments.size() == 0) {
+                    return totalHits == 0 ? BigDecimal.ONE : BigDecimal.ZERO;
+                }
+                return divide(new BigDecimal(relevantItemsFound.get()), relevantDocuments.size());
+            }
+        };
+    }
+}

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/FMeasureAtKTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/FMeasureAtKTestCase.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sease.rre.core.domain.metrics.impl;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.sease.rre.core.BaseTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.sease.rre.core.TestData.*;
+import static java.util.Arrays.stream;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * F Measure at K Test Case.
+ *
+ * @author worleydl
+ */
+public class FMeasureAtKTestCase extends BaseTestCase {
+    /**
+     * Setup fixture for this test case.
+     */
+    @Before
+    public void setUp() {
+        cut = new FMeasureAtK(1.0f, 10);
+        cut.setVersions(Collections.singletonList(A_VERSION));
+        counter = new AtomicInteger(0);
+    }
+
+    /**
+     * Scenario: 15 judgments, 15 search results, 10 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_results_10_relevant_results_at_top() {
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).limit(10).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIFTEEN_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        assertEquals(
+                1.0,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.001);
+    }
+
+    /**
+     * Scenario: 10 judgments, 15 search results, 5 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_results_5_relevant_results() {
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).limit(10).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIVE_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        stream(TEN_SEARCH_HITS)
+                .map(docid -> docid + "_SUFFIX")
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        assertEquals(
+                0.5,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.001);
+    }
+
+    /**
+     * Scenario: 10 judgments, 15 search results, 5 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_results_5_relevant_results_in_the_middle() {
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).limit(10).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIVE_SEARCH_HITS)
+                .map(docid -> docid + "_PRE")
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        stream(FIVE_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        stream(FIVE_SEARCH_HITS)
+                .map(docid -> docid + "_POST")
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        assertEquals(
+                0.5,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.001);
+    }
+}

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionAtKTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionAtKTestCase.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sease.rre.core.domain.metrics.impl;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.sease.rre.core.BaseTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.sease.rre.core.TestData.*;
+import static java.util.Arrays.stream;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Precision at K Test Case.
+ *
+ * @author worleydl
+ */
+public class PrecisionAtKTestCase extends BaseTestCase {
+    /**
+     * Setup fixture for this test case.
+     */
+    @Before
+    public void setUp() {
+        cut = new PrecisionAtK(15);
+        cut.setVersions(Collections.singletonList(A_VERSION));
+        counter = new AtomicInteger(0);
+    }
+
+    /**
+     * If all results in the window are relevant, then the precision is 1.
+     */
+    @Test
+    public void maximumPrecision() {
+       maximum();
+    }
+
+    /**
+     * Scenario: 15 judgments, 15 search results, 10 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_results_10_relevant_results_at_top() {
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).limit(10).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIFTEEN_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        assertEquals(
+                10 / 15d,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.01);
+    }
+
+    /**
+     * Scenario: 10 judgments, 15 search results, 5 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_results_5_relevant_results() {
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).limit(10).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIVE_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        stream(TEN_SEARCH_HITS)
+                .map(docid -> docid + "_SUFFIX")
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        assertEquals(
+                5 / 15d,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.01);
+    }
+
+    /**
+     * Scenario: 10 judgments, 15 search results, 5 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_results_5_relevant_results_in_the_middle() {
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).limit(10).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIVE_SEARCH_HITS)
+                .map(docid -> docid + "_PRE")
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        stream(FIVE_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        stream(FIVE_SEARCH_HITS)
+                .map(docid -> docid + "_POST")
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        assertEquals(
+                5 / 15d,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.01);
+    }
+}

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/RecallAtKTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/RecallAtKTestCase.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sease.rre.core.domain.metrics.impl;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.sease.rre.core.BaseTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.sease.rre.core.TestData.*;
+import static java.util.Arrays.stream;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Recall at K Test Case.
+ *
+ * @author worleydl
+ */
+public class RecallAtKTestCase extends BaseTestCase {
+    /**
+     * Setup fixture for this test case.
+     */
+    @Before
+    public void setUp() {
+        cut = new RecallAtK(15);
+        cut.setVersions(Collections.singletonList(A_VERSION));
+        counter = new AtomicInteger(0);
+    }
+
+    /**
+     * If all results in the window are relevant, then the recall is 1.
+     */
+    @Test
+    public void maximumRecall() {
+       maximum();
+    }
+
+    /**
+     * Scenario: 15 judgments, 15 search results, 10 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_results_10_relevant_results_at_top() {
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).limit(10).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIFTEEN_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        assertEquals(
+                BigDecimal.ONE.doubleValue(),
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.000);
+    }
+
+    /**
+     * Scenario: 10 judgments, 15 search results, 5 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_results_5_relevant_results() {
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).limit(10).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIVE_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        stream(TEN_SEARCH_HITS)
+                .map(docid -> docid + "_SUFFIX")
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        assertEquals(
+                5 / 10d,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.001);
+    }
+
+    /**
+     * Scenario: 10 judgments, 15 search results, 5 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_results_5_relevant_results_in_the_middle() {
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).limit(10).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIVE_SEARCH_HITS)
+                .map(docid -> docid + "_PRE")
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        stream(FIVE_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        stream(FIVE_SEARCH_HITS)
+                .map(docid -> docid + "_POST")
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        assertEquals(
+                5 / 10d,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.001);
+    }
+}


### PR DESCRIPTION
This PR adds FMeasureAtK and RecallAtK which can be used in the new parameterized metrics that were recently added.  I included some test cases as well as a new test case for PrecisionAtK.