### PR TITLE
Expected Reciprocal Rank (ERR) metric

### DIFF
--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/ExpectedReciprocalRank.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/ExpectedReciprocalRank.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sease.rre.core.domain.metrics.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.sease.rre.core.domain.metrics.Metric;
+import io.sease.rre.core.domain.metrics.ValueFactory;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+
+import static io.sease.rre.Func.gainOrRatingNode;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.groupingBy;
+
+/**
+ * ERR metric.
+ *
+ * @author binarymax
+ * @since 1.0
+ */
+public class ExpectedReciprocalRank extends Metric {
+
+    private final BigDecimal maxgrade;
+    private final int k;
+
+    private final static BigDecimal TWO = new BigDecimal(2);
+
+    /**
+     * Builds a new ExpectedReciprocalRank metric with the default gain unit function and one diversity topic.
+     */
+    public ExpectedReciprocalRank(@JsonProperty("maxgrade") final float maxgrade, @JsonProperty("k") final int k) {
+        super("ERR" + "@" + k);
+        this.maxgrade = BigDecimal.valueOf(maxgrade);
+        this.k = k;
+    }
+
+    @Override
+    public ValueFactory createValueFactory(final String version) {
+        return new ValueFactory(this, version) {
+            private BigDecimal ERR = BigDecimal.ZERO;
+            private BigDecimal trust = BigDecimal.ONE;
+
+            @Override
+            public void collect(final Map<String, Object> hit, final int rank, final String version) {
+                if (rank > 10) return;
+                judgment(id(hit))
+                    .ifPresent(judgment -> {
+                        final BigDecimal value = gainOrRatingNode(judgment).map(JsonNode::decimalValue).orElse(TWO);
+                        final BigDecimal r = BigDecimal.valueOf(rank + 1);
+                        final BigDecimal usefulness = gain(value,maxgrade);
+                        final BigDecimal discounted = usefulness.divide(r);
+                        ERR = ERR.add(trust.multiply(discounted));
+                        trust = trust.multiply(usefulness.add(BigDecimal.ONE));
+                    });
+            }
+
+            @Override
+            public BigDecimal value() {
+                return ERR;
+            }
+        };
+    }
+
+    private BigDecimal gain(BigDecimal grade, BigDecimal max) {
+        final BigDecimal denom = TWO.pow(max.intValue());
+        final BigDecimal numer =TWO.pow(grade.intValue()).subtract(BigDecimal.ONE);
+        if (denom.equals(BigDecimal.ZERO)) {
+            return BigDecimal.ZERO;
+        }
+        return numer.divide(denom);
+    }
+}

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/ExpectedReciprocalRankTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/ExpectedReciprocalRankTestCase.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sease.rre.core.domain.metrics.impl;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.sease.rre.core.BaseTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.sease.rre.core.TestData.*;
+import static java.util.Arrays.stream;
+import static org.junit.Assert.assertEquals;
+
+public class ExpectedReciprocalRankTestCase extends BaseTestCase {
+
+    @Before
+    public void setUp() {
+        cut = new ExpectedReciprocalRank(3, 10);
+        cut.setVersions(Collections.singletonList(A_VERSION));
+        counter = new AtomicInteger(0);
+    }
+
+
+    /**
+     * Scenario: 15 judgments, 15 search results, 10 relevant results in top positions. NDCG = 1
+     */
+    @Test
+    public void _10_judgments_15_search_results_10_relevant_results_at_top() {
+        //System.out.println("_10_judgments_15_search_results_10_relevant_results_at_top");
+
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).limit(10).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIFTEEN_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+        //System.out.println("_10_judgments_15_search_results_10_relevant_results_at_top");
+        assertEquals(
+                0.935,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.2);
+    }
+
+    /**
+     * Scenario: 10 judgments, 15 search results, 5 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_results_5_relevant_results_at_top() {
+        //System.out.println("_10_judgments_15_search_results_5_relevant_results_at_top");
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).limit(10).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIVE_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+
+        stream(TEN_SEARCH_HITS)
+                .map(docid -> docid + "_SUFFIX")
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+        //System.out.println("_10_judgments_15_search_results_5_relevant_results_at_top");
+        assertEquals(
+                0.935,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.02);
+    }
+
+    /**
+     * Scenario: 10 judgments, 15 search results, 5 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_results_5_relevant_results_from_5th_to_10th() {
+        //System.out.println("_10_judgments_15_search_results_5_relevant_results_from_5th_to_10th");
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).skip(5).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIFTEEN_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+        //System.out.println("_10_judgments_15_search_results_5_relevant_results_from_5th_to_10th");
+        assertEquals(
+                0.591,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.02);
+    }
+
+    /**
+     * Scenario: 10 judgments, 15 search results, 5 relevant results in top positions.
+     */
+    @Test
+    public void _10_judgments_15_search_only_10th_result_relevant() {
+        //System.out.println("_10_judgments_15_search_only_10th_result_relevant");
+        final ObjectNode judgements = mapper.createObjectNode();
+        stream(FIFTEEN_SEARCH_HITS).skip(9).limit(1).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
+        cut.setRelevantDocuments(judgements);
+
+        cut.setTotalHits(FIFTEEN_SEARCH_HITS.length, A_VERSION);
+        stream(FIFTEEN_SEARCH_HITS)
+                .map(this::searchHit)
+                .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
+        //System.out.println("_10_judgments_15_search_only_10th_result_relevant");
+        assertEquals(
+                0.589,
+                cut.valueFactory(A_VERSION).value().doubleValue(),
+                0.02);
+    }
+}


### PR DESCRIPTION
This adds the ERR metric capability.  The metric is described in the paper "Expected Reciprocal Rank for Graded Relevance":  http://www.olivier.chapelle.cc/pub/err.pdf 

As implemented in this pull request, it uses the default gain function of ((2^value)-1)/(2^max).  No topic diversity capability is currently implemented.  The default cascade model of (1/rank) is also used.  This metric will be extended in the future to allow variations on the gain function, cascade model, and a multiple diversity setting.