### PR TITLE
Ensure that a minimum of K results are retrieved for metric@K metrics.

### DIFF
--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/Metric.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/Metric.java
@@ -48,6 +48,9 @@ import static java.util.stream.IntStream.range;
  * @since 1.0
  */
 public abstract class Metric implements HitsCollector {
+
+    public static final int DEFAULT_REQUIRED_RESULTS = 10;
+
     private final String name;
 
     protected String idFieldName = DEFAULT_ID_FIELD_NAME;
@@ -163,5 +166,9 @@ public abstract class Metric implements HitsCollector {
      */
     public ValueFactory valueFactory(final String version) {
         return values.get(version);
+    }
+
+    public int getRequiredResults() {
+        return DEFAULT_REQUIRED_RESULTS;
     }
 }

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/ExpectedReciprocalRank.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/ExpectedReciprocalRank.java
@@ -101,4 +101,9 @@ public class ExpectedReciprocalRank extends Metric {
         }
         return numer.divide(denom,8,RoundingMode.HALF_UP);
     }
+
+    @Override
+    public int getRequiredResults() {
+        return k;
+    }
 }

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/FMeasureAtK.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/FMeasureAtK.java
@@ -107,4 +107,9 @@ public class FMeasureAtK extends Metric {
         precision.setIdFieldName(idFieldName);
         recall.setIdFieldName(idFieldName);
     }
+
+    @Override
+    public int getRequiredResults() {
+        return k;
+    }
 }

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/PrecisionAtK.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/PrecisionAtK.java
@@ -69,4 +69,9 @@ public class PrecisionAtK extends Metric {
             }
         };
     }
+
+    @Override
+    public int getRequiredResults() {
+        return k;
+    }
 }

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/RecallAtK.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/RecallAtK.java
@@ -50,4 +50,9 @@ public class RecallAtK extends Metric {
             }
         };
     }
+
+    @Override
+    public int getRequiredResults() {
+        return k;
+    }
 }

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/AveragePrecisionTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/AveragePrecisionTestCase.java
@@ -18,6 +18,7 @@ package io.sease.rre.core.domain.metrics.impl;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sease.rre.core.BaseTestCase;
+import io.sease.rre.core.domain.metrics.Metric;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +45,11 @@ public class AveragePrecisionTestCase extends BaseTestCase {
         cut = new AveragePrecision();
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
+    }
+
+    @Test
+    public void minimumResultsMatchesDefault() {
+        assertEquals(Metric.DEFAULT_REQUIRED_RESULTS, cut.getRequiredResults());
     }
 
     /**

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/ExpectedReciprocalRankTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/ExpectedReciprocalRankTestCase.java
@@ -30,13 +30,19 @@ import static org.junit.Assert.assertEquals;
 
 public class ExpectedReciprocalRankTestCase extends BaseTestCase {
 
+    private static final int K = 10;
+
     @Before
     public void setUp() {
-        cut = new ExpectedReciprocalRank(3, 10);
+        cut = new ExpectedReciprocalRank(3, K);
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
     }
 
+    @Test
+    public void minimumResultsMatchesK() {
+        assertEquals(K, cut.getRequiredResults());
+    }
 
     /**
      * Scenario: 15 judgments, 15 search results, 10 relevant results in top positions. NDCG = 1

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/F0_5TestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/F0_5TestCase.java
@@ -18,6 +18,7 @@ package io.sease.rre.core.domain.metrics.impl;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sease.rre.core.BaseTestCase;
+import io.sease.rre.core.domain.metrics.Metric;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +45,11 @@ public class F0_5TestCase extends BaseTestCase {
         cut = new F0_5();
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
+    }
+
+    @Test
+    public void minimumResultsMatchesDefault() {
+        assertEquals(Metric.DEFAULT_REQUIRED_RESULTS, cut.getRequiredResults());
     }
 
     /**

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/F1TestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/F1TestCase.java
@@ -18,6 +18,7 @@ package io.sease.rre.core.domain.metrics.impl;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sease.rre.core.BaseTestCase;
+import io.sease.rre.core.domain.metrics.Metric;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +45,11 @@ public class F1TestCase extends BaseTestCase {
         cut = new F1();
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
+    }
+
+    @Test
+    public void minimumResultsMatchesDefault() {
+        assertEquals(Metric.DEFAULT_REQUIRED_RESULTS, cut.getRequiredResults());
     }
 
     /**

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/F2TestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/F2TestCase.java
@@ -18,6 +18,7 @@ package io.sease.rre.core.domain.metrics.impl;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sease.rre.core.BaseTestCase;
+import io.sease.rre.core.domain.metrics.Metric;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +45,11 @@ public class F2TestCase extends BaseTestCase {
         cut = new F2();
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
+    }
+
+    @Test
+    public void minimumResultsMatchesDefault() {
+        assertEquals(Metric.DEFAULT_REQUIRED_RESULTS, cut.getRequiredResults());
     }
 
     /**

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/FMeasureAtKTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/FMeasureAtKTestCase.java
@@ -34,14 +34,22 @@ import static org.junit.Assert.assertEquals;
  * @author worleydl
  */
 public class FMeasureAtKTestCase extends BaseTestCase {
+
+    private static final int K = 10;
+
     /**
      * Setup fixture for this test case.
      */
     @Before
     public void setUp() {
-        cut = new FMeasureAtK(1.0f, 10);
+        cut = new FMeasureAtK(1.0f, K);
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
+    }
+
+    @Test
+    public void minimumResultsMatchesK() {
+        assertEquals(K, cut.getRequiredResults());
     }
 
     /**

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/NDCGAtTenTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/NDCGAtTenTestCase.java
@@ -18,6 +18,7 @@ package io.sease.rre.core.domain.metrics.impl;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sease.rre.core.BaseTestCase;
+import io.sease.rre.core.domain.metrics.Metric;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,6 +36,11 @@ public class NDCGAtTenTestCase extends BaseTestCase {
         cut = new NDCGAtTen();
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
+    }
+
+    @Test
+    public void minimumResultsMatchesDefault() {
+        assertEquals(Metric.DEFAULT_REQUIRED_RESULTS, cut.getRequiredResults());
     }
 
     /**

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionAtKTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionAtKTestCase.java
@@ -34,12 +34,15 @@ import static org.junit.Assert.assertEquals;
  * @author worleydl
  */
 public class PrecisionAtKTestCase extends BaseTestCase {
+
+    private static final int K = 15;
+
     /**
      * Setup fixture for this test case.
      */
     @Before
     public void setUp() {
-        cut = new PrecisionAtK(15);
+        cut = new PrecisionAtK(K);
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
     }
@@ -50,6 +53,11 @@ public class PrecisionAtKTestCase extends BaseTestCase {
     @Test
     public void maximumPrecision() {
        maximum();
+    }
+
+    @Test
+    public void minimumResultsMatchesK() {
+        assertEquals(K, cut.getRequiredResults());
     }
 
     /**

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionAtOneTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionAtOneTestCase.java
@@ -18,6 +18,7 @@ package io.sease.rre.core.domain.metrics.impl;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sease.rre.core.BaseTestCase;
+import io.sease.rre.core.domain.metrics.Metric;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,6 +44,11 @@ public class PrecisionAtOneTestCase extends BaseTestCase {
         cut = new PrecisionAtOne();
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
+    }
+
+    @Test
+    public void minimumResultsMatchesK() {
+        assertEquals(1, cut.getRequiredResults());
     }
 
     /**

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionAtThreeTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionAtThreeTestCase.java
@@ -46,6 +46,11 @@ public class PrecisionAtThreeTestCase extends BaseTestCase {
         counter = new AtomicInteger(0);
     }
 
+    @Test
+    public void minimumResultsMatchesK() {
+        assertEquals(3, cut.getRequiredResults());
+    }
+
     /**
      * If all results in the window are relevant, then the precision is 1.
      */

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionAtTwoTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionAtTwoTestCase.java
@@ -46,6 +46,11 @@ public class PrecisionAtTwoTestCase extends BaseTestCase {
         counter = new AtomicInteger(0);
     }
 
+    @Test
+    public void minimumResultsMatchesK() {
+        assertEquals(2, cut.getRequiredResults());
+    }
+
     /**
      * If all results in the window are relevant, then the precision is 1.
      */

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/PrecisionTestCase.java
@@ -18,6 +18,7 @@ package io.sease.rre.core.domain.metrics.impl;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sease.rre.core.BaseTestCase;
+import io.sease.rre.core.domain.metrics.Metric;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,6 +44,11 @@ public class PrecisionTestCase extends BaseTestCase {
         cut = new Precision();
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
+    }
+
+    @Test
+    public void minimumResultsMatchesK() {
+        assertEquals(Metric.DEFAULT_REQUIRED_RESULTS, cut.getRequiredResults());
     }
 
     /**

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/RecallAtKTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/RecallAtKTestCase.java
@@ -35,14 +35,22 @@ import static org.junit.Assert.assertEquals;
  * @author worleydl
  */
 public class RecallAtKTestCase extends BaseTestCase {
+
+    private static final int K = 15;
+
     /**
      * Setup fixture for this test case.
      */
     @Before
     public void setUp() {
-        cut = new RecallAtK(15);
+        cut = new RecallAtK(K);
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
+    }
+
+    @Test
+    public void minimumResultsMatchesK() {
+        assertEquals(K, cut.getRequiredResults());
     }
 
     /**

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/RecallTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/RecallTestCase.java
@@ -18,6 +18,7 @@ package io.sease.rre.core.domain.metrics.impl;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sease.rre.core.BaseTestCase;
+import io.sease.rre.core.domain.metrics.Metric;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +45,11 @@ public class RecallTestCase extends BaseTestCase {
         cut = new Recall();
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger(0);
+    }
+
+    @Test
+    public void minimumResultsMatchesK() {
+        assertEquals(Metric.DEFAULT_REQUIRED_RESULTS, cut.getRequiredResults());
     }
 
     /**

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/ReciprocalRankTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/ReciprocalRankTestCase.java
@@ -18,6 +18,7 @@ package io.sease.rre.core.domain.metrics.impl;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sease.rre.core.BaseTestCase;
+import io.sease.rre.core.domain.metrics.Metric;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,6 +46,11 @@ public class ReciprocalRankTestCase extends BaseTestCase {
         cut = new ReciprocalRank();
         cut.setVersions(Collections.singletonList(A_VERSION));
         counter = new AtomicInteger();
+    }
+
+    @Test
+    public void minimumResultsMatchesK() {
+        assertEquals(Metric.DEFAULT_REQUIRED_RESULTS, cut.getRequiredResults());
     }
 
     /**


### PR DESCRIPTION
This is a quick modification to ensure that at least _k_ results are available when using metric @ _k_ metrics - eg. if someone uses P@20, there are 20 results to compare against the judgements, rather than stopping at 10.