### PR TITLE
Bugfix: incorrect evaluation counts reported when running multiple ratings sets

### DIFF
--- a/rre-core/pom.xml
+++ b/rre-core/pom.xml
@@ -55,5 +55,11 @@
             <artifactId>mockito-core</artifactId>
             <version>2.26.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/rre-core/src/main/java/io/sease/rre/core/Engine.java
+++ b/rre-core/src/main/java/io/sease/rre/core/Engine.java
@@ -489,7 +489,10 @@ public class Engine {
             }
         }
 
-        this.evaluationManager = EvaluationManagerFactory.instantiateEvaluationManager(evaluationConfiguration, platform, persistenceManager, templateManager, fields, versions, versionTimestamp);
+        // Initialise the evaluation manager, if it doesn't already exist
+        if (evaluationManager == null) {
+            evaluationManager = EvaluationManagerFactory.instantiateEvaluationManager(evaluationConfiguration, platform, persistenceManager, templateManager, fields, versions, versionTimestamp);
+        }
 
         flushFileChecksums();
 

--- a/rre-core/src/main/java/io/sease/rre/core/version/VersionManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/version/VersionManager.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sease.rre.core.version;
+
+import java.io.File;
+import java.util.Collection;
+
+/**
+ * A manager for fetching the versions and version folders to be used during
+ * an evaluation.
+ *
+ * @author Matt Pearce (matt@flax.co.uk)
+ */
+public interface VersionManager {
+
+    /**
+     * Retrieve the folders holding the configuration sets to be evaluated.
+     * @return a collection of folders.
+     */
+    Collection<File> getConfigurationVersionFolders();
+
+    /**
+     * Retrieve the names of the configuration set versions to be evaluated.
+     * @return a collection of strings holding the version names.
+     */
+    Collection<String> getConfigurationVersions();
+
+    /**
+     * Retrieve the version timestamp to use, if appropriate.
+     *
+     * This is set in the persistence configuration, and will only be set if
+     * there is a single configuration set in use during this evaluation.
+     *
+     * @return the version timestamp, or {@code null} if not appropriate.
+     */
+    String getVersionTimestamp();
+}

--- a/rre-core/src/main/java/io/sease/rre/core/version/VersionManagerImpl.java
+++ b/rre-core/src/main/java/io/sease/rre/core/version/VersionManagerImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sease.rre.core.version;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static io.sease.rre.Func.ONLY_DIRECTORIES;
+import static io.sease.rre.Func.safe;
+import static java.util.Arrays.stream;
+
+/**
+ * Basic implementation of the VersionManager interface.
+ *
+ * @author Matt Pearce (mpearce@opensourceconnections.com)
+ */
+public class VersionManagerImpl implements VersionManager {
+
+    private static final Logger LOGGER = LogManager.getLogger(VersionManagerImpl.class);
+
+    private final Collection<File> configurationVersionFolders;
+    private final Collection<String> configurationVersions;
+    private final String versionTimestamp;
+
+    public VersionManagerImpl(File configurationSetFolder, Collection<String> include, Collection<String> exclude, boolean useTimestampAsVersion) {
+        configurationVersionFolders = Arrays.asList(
+                findConfigurationFolders(configurationSetFolder,
+                        Optional.ofNullable(include).orElse(Collections.emptyList()),
+                        Optional.ofNullable(exclude).orElse(Collections.emptyList())));
+        if (configurationVersionFolders.isEmpty()) {
+            throw new IllegalArgumentException("RRE: no target versions available. Check the configuration set folder and include/exclude clauses.");
+        }
+
+        this.configurationVersions = configurationVersionFolders.stream()
+                .map(File::getName)
+                .sorted()
+                .collect(Collectors.toList());
+
+        versionTimestamp = useTimestampAsVersion ? calculateVersionTimestamp() : null;
+    }
+
+    private File[] findConfigurationFolders(File configurationSetFolder, Collection<String> include, Collection<String> exclude) {
+        return safe(configurationSetFolder.listFiles(
+                file -> ONLY_DIRECTORIES.accept(file)
+                        && (include.isEmpty() || include.contains(file.getName()) || include.stream().anyMatch(rule -> file.getName().matches(rule)))
+                        && (exclude.isEmpty() || (!exclude.contains(file.getName()) && exclude.stream().noneMatch(rule -> file.getName().matches(rule))))));
+    }
+
+    private String calculateVersionTimestamp() {
+        final String ret;
+        if (configurationVersions.size() == 1) {
+            ret = String.valueOf(System.currentTimeMillis());
+            LOGGER.info("Using local system timestamp as version tag : " + versionTimestamp);
+        } else {
+            LOGGER.warn("Persistence.useTimestampAsVersion == true, but multiple configurations exist - ignoring");
+            ret = null;
+        }
+        return ret;
+    }
+
+    @Override
+    public Collection<File> getConfigurationVersionFolders() {
+        return configurationVersionFolders;
+    }
+
+    @Override
+    public Collection<String> getConfigurationVersions() {
+        return configurationVersions;
+    }
+
+    @Override
+    public String getVersionTimestamp() {
+        return versionTimestamp;
+    }
+}

--- a/rre-core/src/test/java/io/sease/rre/core/version/VersionManagerImplTest.java
+++ b/rre-core/src/test/java/io/sease/rre/core/version/VersionManagerImplTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sease.rre.core.version;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for the version manager implementation.
+ *
+ * @author Matt Pearce (mpearce@opensourceconnections.com)
+ */
+public class VersionManagerImplTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private File configFolder;
+
+    @Before
+    public void setupConfigFolder() throws Exception {
+        configFolder = tmp.newFolder();
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void constructorThrowsIllegalArgument_whenNoFoldersAvailable() {
+        new VersionManagerImpl(configFolder, null, null, false);
+    }
+
+    @Test
+    public void constructorInitialisesWithSingleFolder() throws Exception {
+        File v1 = new File(configFolder, "v1");
+        Files.createDirectory(v1.toPath());
+
+        VersionManager vm = new VersionManagerImpl(configFolder, null, null, false);
+
+        assertThat(vm.getConfigurationVersionFolders()).containsExactly(v1);
+        assertThat(vm.getConfigurationVersions()).containsExactly("v1");
+        assertThat(vm.getVersionTimestamp()).isNull();
+    }
+
+    @Test
+    public void constructorInitialisesWithMultipleFolders() throws Exception {
+        File v1 = new File(configFolder, "v1");
+        Files.createDirectory(v1.toPath());
+        File v2 = new File(configFolder, "v2");
+        Files.createDirectory(v2.toPath());
+        File x1 = new File(configFolder, "x1");
+        Files.createDirectory(x1.toPath());
+
+        VersionManager vm = new VersionManagerImpl(configFolder, null, null, false);
+
+        assertThat(vm.getConfigurationVersionFolders()).contains(v1, v2, x1);
+        assertThat(vm.getConfigurationVersions()).containsExactly("v1", "v2", "x1");
+        assertThat(vm.getVersionTimestamp()).isNull();
+    }
+
+    @Test
+    public void constructorInitialisesWithIncludes() throws Exception {
+        File v1 = new File(configFolder, "v1");
+        Files.createDirectory(v1.toPath());
+        File v2 = new File(configFolder, "v2");
+        Files.createDirectory(v2.toPath());
+
+        VersionManager vm = new VersionManagerImpl(configFolder, Collections.singleton("v2"), null, false);
+
+        assertThat(vm.getConfigurationVersionFolders()).containsExactly(v2);
+        assertThat(vm.getConfigurationVersions()).containsExactly("v2");
+        assertThat(vm.getVersionTimestamp()).isNull();
+    }
+
+    @Test
+    public void constructorInitialisesWithExcludes() throws Exception {
+        File v1 = new File(configFolder, "v1");
+        Files.createDirectory(v1.toPath());
+        File v2 = new File(configFolder, "v2");
+        Files.createDirectory(v2.toPath());
+
+        VersionManager vm = new VersionManagerImpl(configFolder, null, Collections.singleton("v2"), false);
+
+        assertThat(vm.getConfigurationVersionFolders()).containsExactly(v1);
+        assertThat(vm.getConfigurationVersions()).containsExactly("v1");
+        assertThat(vm.getVersionTimestamp()).isNull();
+    }
+
+    @Test
+    public void constructorInitialisesWithVersionTimestamp() throws Exception {
+        File v1 = new File(configFolder, "v1");
+        Files.createDirectory(v1.toPath());
+
+        VersionManager vm = new VersionManagerImpl(configFolder, null, null, true);
+
+        assertThat(vm.getConfigurationVersionFolders()).containsExactly(v1);
+        assertThat(vm.getConfigurationVersions()).containsExactly("v1");
+        assertThat(vm.getVersionTimestamp()).isNotNull();
+    }
+
+    @Test
+    public void constructorIgnoresTimestampFlag_withMultipleFolders() throws Exception {
+        File v1 = new File(configFolder, "v1");
+        Files.createDirectory(v1.toPath());
+        File v2 = new File(configFolder, "v2");
+        Files.createDirectory(v2.toPath());
+
+        VersionManager vm = new VersionManagerImpl(configFolder, null, null, true);
+
+        assertThat(vm.getConfigurationVersionFolders().size()).isEqualTo(2);
+        assertThat(vm.getVersionTimestamp()).isNull();
+    }
+}


### PR DESCRIPTION
We noticed that if we had two or more ratings files, the evaluation count written to screen only showed the count for the final set. The output data had evaluations from all rating sets though, so the count was confusing.

I tracked this down to the EvaluationManager being created once per rating set in `Engine.prepareData()`, which led to some refactoring so that the EvaluationManager could be made into a single instance within the Engine class. I also pulled the configuration version handling into its own manager class. This fixes the output counts, and makes the configuration version management a bit easier to test. :-)