### PR TITLE
Add support for basic authentication to external ES platform

### DIFF
--- a/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/configuration_sets/README.md
+++ b/rre-maven-archetype/rre-maven-external-elasticsearch-archetype/src/main/resources/archetype-resources/src/etc/configuration_sets/README.md
@@ -4,3 +4,5 @@ Each version folder should contain the index settings associated with such versi
 - `hostUrls`: an array of URLs where the Elasticsearch instance for this
 version can be accessed.
 - `index`: the name of the index holding the data being used to search.
+- `user`: basic auth username (optional)
+- `password`: basic auth password (optional)


### PR DESCRIPTION
Currently external Elasticsearch setup does not support basic auth (encoding user/password into `hostUrl` does not work - tried that). Elasticsearch REST client documentation shows how this should be done:
https://www.elastic.co/guide/en/elasticsearch/client/java-rest/5.6/_basic_authentication.html

So I've extended `index-settings.json` with optional `user` and `password` params that are used for setting up basic auth (if present).