### PR TITLE
Bugfix for asynchronous metric issues

### DIFF
--- a/rre-core/src/main/java/io/sease/rre/core/Engine.java
+++ b/rre-core/src/main/java/io/sease/rre/core/Engine.java
@@ -93,7 +93,7 @@ public class Engine {
 
     private FileUpdateChecker fileUpdateChecker;
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
 
     private final PersistenceManager persistenceManager;
 
@@ -151,6 +151,38 @@ public class Engine {
                 versionManager.getVersionTimestamp());
 
         initialiseFileUpdateChecker(checksumFilepath);
+    }
+
+    /**
+     * Fully parameterised constructor, does no initialisation apart from
+     * setting up the checksum file, if required.
+     *
+     * @param platform           the search platform.
+     * @param corporaFolder      the folder holding the corpora data (optional).
+     * @param ratingsFolder      the folder holding the ratings details.
+     * @param checksumFile       the path to the checksum file (optional).
+     * @param metricClassManager a fully initialised metric class manager.
+     * @param persistenceManager a fully initialised persistence manager.
+     * @param versionManager     a fully initialised version manager.
+     * @param evaluationManager  a fully initialised evaluation manager.
+     */
+    public Engine(
+            final SearchPlatform platform,
+            final File corporaFolder,
+            final File ratingsFolder,
+            final String checksumFile,
+            final MetricClassManager metricClassManager,
+            final PersistenceManager persistenceManager,
+            final VersionManager versionManager,
+            final EvaluationManager evaluationManager) {
+        this.platform = platform;
+        this.corporaFolder = corporaFolder;
+        this.ratingsFolder = ratingsFolder;
+        this.metricClassManager = metricClassManager;
+        this.persistenceManager = persistenceManager;
+        this.versionManager = versionManager;
+        this.evaluationManager = evaluationManager;
+        initialiseFileUpdateChecker(checksumFile);
     }
 
     private void initialiseFileUpdateChecker(String checksumFile) {

--- a/rre-core/src/main/java/io/sease/rre/core/domain/Query.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/Query.java
@@ -24,7 +24,12 @@ import io.sease.rre.core.domain.metrics.HitsCollector;
 import io.sease.rre.core.domain.metrics.Metric;
 import io.sease.rre.core.domain.metrics.MetricClassConfigurationManager;
 
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
@@ -50,7 +55,7 @@ public class Query extends DomainMember<Query> implements HitsCollector {
     }
 
     @JsonProperty("results")
-    private Map<String, MutableQueryOrSearchResponse> results = new LinkedHashMap<>();
+    private final Map<String, MutableQueryOrSearchResponse> results = Collections.synchronizedMap(new LinkedHashMap<>());
 
     @Override
     @JsonProperty("query")

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/AveragedMetric.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/AveragedMetric.java
@@ -89,7 +89,7 @@ public class AveragedMetric extends Metric {
      * @param version         the version associated with the collected (metric) value.
      * @param additionalValue the collected value.
      */
-    public void collect(final String version, final BigDecimal additionalValue) {
+    public synchronized void collect(final String version, final BigDecimal additionalValue) {
         ((MutableValueFactory)
                 values.computeIfAbsent(version, this::createValueFactory))
                 .collect(additionalValue);

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/AveragedMetricMultiThreadTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/AveragedMetricMultiThreadTestCase.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sease.rre.core.domain.metrics.impl;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A test case to ensure that the AveragedMetric handles multi-threaded
+ * collect() calls as expected.
+ *
+ * @author Matt Pearce (matt@elysiansoftware.co.uk)
+ */
+public class AveragedMetricMultiThreadTestCase {
+
+    private static final int NUM_THREADS = 8;
+
+    private List<String> versions;
+
+    @Before
+    public void initialiseVersions() {
+        versions = new ArrayList<>();
+        for (int i = 0; i < (Math.random() * 100); i ++) {
+            versions.add("" + i);
+        }
+    }
+
+    @After
+    public void tearDownVersions() {
+        versions = null;
+    }
+
+    @Test
+    public void singleThreadTest() {
+        AveragedMetric am = new AveragedMetric("test");
+        for (String v : versions) {
+            am.collect(v, BigDecimal.ONE);
+        }
+
+        assertThat(am.getVersions().keySet()).containsAll(versions);
+    }
+
+    @Test
+    public void multiThreadTest() throws Exception {
+        AveragedMetric am = new AveragedMetric("test");
+
+        ExecutorService executorService = Executors.newFixedThreadPool(NUM_THREADS);
+        Collection<Future<?>> futures = versions.stream()
+                .map(v -> new Thread(() -> am.collect(v, BigDecimal.ONE)))
+                .map(executorService::submit)
+                .collect(Collectors.toList());
+        for (Future<?> f : futures) {
+            if (!f.isDone()) {
+                Thread.sleep(10);
+            }
+        }
+
+        assertThat(am.getVersions().keySet()).containsAll(versions);
+    }
+}

--- a/rre-core/src/test/java/io/sease/rre/core/EngineEvaluationTest.java
+++ b/rre-core/src/test/java/io/sease/rre/core/EngineEvaluationTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sease.rre.core;
+
+import io.sease.rre.core.domain.DomainMember;
+import io.sease.rre.core.domain.Evaluation;
+import io.sease.rre.core.domain.metrics.MetricClassConfigurationManager;
+import io.sease.rre.core.domain.metrics.MetricClassManager;
+import io.sease.rre.core.evaluation.EvaluationConfiguration;
+import io.sease.rre.core.evaluation.EvaluationManager;
+import io.sease.rre.core.evaluation.EvaluationManagerFactory;
+import io.sease.rre.core.template.QueryTemplateManager;
+import io.sease.rre.core.template.impl.CachingQueryTemplateManager;
+import io.sease.rre.core.version.VersionManager;
+import io.sease.rre.persistence.PersistenceManager;
+import io.sease.rre.search.api.QueryOrSearchResponse;
+import io.sease.rre.search.api.SearchPlatform;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the Engine's evaluate method, attempting to ensure that
+ * the returned output contains everything we think it should.
+ *
+ * @author Matt Pearce (matt@elysiansoftware.co.uk)
+ */
+public class EngineEvaluationTest {
+
+    private static final String ID_FIELD = "id";
+    private static final int MAX_VERSIONS = 16;
+    private static final Collection<String> SIMPLE_METRICS = Arrays.asList(
+            "io.sease.rre.core.domain.metrics.impl.PrecisionAtOne",
+            "io.sease.rre.core.domain.metrics.impl.PrecisionAtTwo",
+            "io.sease.rre.core.domain.metrics.impl.PrecisionAtThree",
+            "io.sease.rre.core.domain.metrics.impl.PrecisionAtTen"
+    );
+    private static final int THREADPOOL_SIZE = 8;
+    @SuppressWarnings("rawtypes")
+    private static final Map<String, Map> PARAMETERIZED_METRICS = new HashMap<>();
+    private static final String COLLECTION = "basses";
+    private static final String[] FIELDS = new String[]{ ID_FIELD };
+    private static final int MAX_ROWS = 10;
+
+    private static final String BASE_FOLDER_PATH = "src/test/resources/engine_evaluation_tests";
+    private static final String RATINGS_FOLDER_PATH = BASE_FOLDER_PATH + "/ratings";
+    private static final String TEMPLATES_FOLDER_PATH = BASE_FOLDER_PATH + "/templates";
+
+    private static final Random random = new Random();
+
+    private final SearchPlatform searchPlatform = mock(SearchPlatform.class);
+    private final File corporaFolder = null;
+    private final File ratingsFolder = new File(RATINGS_FOLDER_PATH);
+    private final String checksumFilepath = null;
+    private final QueryTemplateManager templateManager = new CachingQueryTemplateManager(TEMPLATES_FOLDER_PATH);
+    private final PersistenceManager persistenceManager = mock(PersistenceManager.class);
+
+    private List<String> versions;
+    private VersionManager versionManager;
+    private MetricClassManager metricClassManager;
+
+    @BeforeClass
+    public static void initialiseParameterisedMetrics() {
+        final Map<String, Object> errConfig = new HashMap<>();
+        errConfig.put("class", "io.sease.rre.core.domain.metrics.impl.ExpectedReciprocalRank");
+        errConfig.put("k", 10);
+        PARAMETERIZED_METRICS.put("ERR@10", errConfig);
+    }
+
+    @Before
+    public void initialiseVersions() {
+        final int numVersions = random.nextInt(MAX_VERSIONS) + 1;
+        versions = new ArrayList<>(numVersions);
+        for (int i = 0; i < numVersions; i ++) {
+            versions.add("v" + i);
+        }
+        versionManager = mock(VersionManager.class);
+        when(versionManager.getConfigurationVersions()).thenReturn(versions);
+    }
+
+    @Before
+    public void initialiseMetrics() {
+        metricClassManager = MetricClassConfigurationManager.getInstance()
+                .buildMetricClassManager(SIMPLE_METRICS, PARAMETERIZED_METRICS);
+    }
+
+    @Before
+    public void initialiseSearchPlatform() {
+        when(searchPlatform.executeQuery(eq(COLLECTION), anyString(), anyString(), eq(FIELDS), eq(MAX_ROWS)))
+                .thenReturn(generateRandomResults());
+    }
+
+    private QueryOrSearchResponse generateRandomResults() {
+        final int numResults = random.nextInt(MAX_ROWS) + 1;
+        final List<Map<String, Object>> results = new ArrayList<>(numResults);
+        for (int i = numResults; i > 0; i --) {
+            Map<String, Object> item = new HashMap<>();
+            item.put(ID_FIELD, "" + (char)('a' + random.nextInt(26)) + random.nextInt());
+            results.add(item);
+        }
+        return new QueryOrSearchResponse(numResults, results);
+    }
+
+
+    @Test
+    public void runSynchronousTests() throws Exception {
+        final EvaluationConfiguration evaluationConfiguration = mock(EvaluationConfiguration.class);
+        when(evaluationConfiguration.isRunAsync()).thenReturn(false);
+        EvaluationManager evaluationManager = EvaluationManagerFactory.instantiateEvaluationManager(evaluationConfiguration,
+                searchPlatform, persistenceManager, templateManager, FIELDS, versions, null);
+
+        final Engine engine = new Engine(searchPlatform, corporaFolder, ratingsFolder, checksumFilepath,
+                metricClassManager, persistenceManager, versionManager, evaluationManager);
+        Evaluation evaluation = engine.evaluate(Collections.emptyMap());
+
+        // Verify the evaluation contains all the expected metrics
+        verifyEvaluationMetricVersions(evaluation);
+    }
+
+    @Test
+    public void runAsynchronousTests() throws Exception {
+        final EvaluationConfiguration evaluationConfiguration = mock(EvaluationConfiguration.class);
+        when(evaluationConfiguration.isRunAsync()).thenReturn(true);
+        when(evaluationConfiguration.isRunQueriesAsync()).thenReturn(false);
+        when(evaluationConfiguration.getThreadpoolSize()).thenReturn(THREADPOOL_SIZE);
+        EvaluationManager evaluationManager = EvaluationManagerFactory.instantiateEvaluationManager(evaluationConfiguration,
+                searchPlatform, persistenceManager, templateManager, FIELDS, versions, null);
+
+        final Engine engine = new Engine(searchPlatform, corporaFolder, ratingsFolder, checksumFilepath,
+                metricClassManager, persistenceManager, versionManager, evaluationManager);
+        Evaluation evaluation = engine.evaluate(Collections.emptyMap());
+
+        // Verify the evaluation contains all the expected metrics
+        verifyEvaluationMetricVersions(evaluation);
+    }
+
+    @Test
+    public void runAsynchronousQueryTests() throws Exception {
+        final EvaluationConfiguration evaluationConfiguration = mock(EvaluationConfiguration.class);
+        when(evaluationConfiguration.isRunAsync()).thenReturn(true);
+        when(evaluationConfiguration.isRunQueriesAsync()).thenReturn(true);
+        when(evaluationConfiguration.getThreadpoolSize()).thenReturn(THREADPOOL_SIZE);
+        EvaluationManager evaluationManager = EvaluationManagerFactory.instantiateEvaluationManager(evaluationConfiguration,
+                searchPlatform, persistenceManager, templateManager, FIELDS, versions, null);
+
+        final Engine engine = new Engine(searchPlatform, corporaFolder, ratingsFolder, checksumFilepath,
+                metricClassManager, persistenceManager, versionManager, evaluationManager);
+        Evaluation evaluation = engine.evaluate(Collections.emptyMap());
+
+        // Verify the evaluation contains all the expected metrics
+        verifyEvaluationMetricVersions(evaluation);
+    }
+
+    private void verifyEvaluationMetricVersions(Evaluation evaluation) {
+        assertThat(evaluation.getMetrics().size()).isEqualTo(SIMPLE_METRICS.size() + PARAMETERIZED_METRICS.size());
+        verifyMetrics(evaluation);
+        evaluation.getChildren().forEach(corpus -> {
+            verifyMetrics(corpus);
+            corpus.getChildren().forEach(topic -> {
+                verifyMetrics(topic);
+                topic.getChildren().forEach(queryGroup -> {
+                    verifyMetrics(queryGroup);
+                    queryGroup.getChildren().forEach(this::verifyMetrics);
+                });
+            });
+        });
+    }
+
+    private void verifyMetrics(DomainMember<?> dm) {
+        dm.getMetrics().values().forEach(m -> {
+            assertThat(m.getVersions().keySet())
+                    .as("Check versions for metric %s [%s] in %s", m.getName(), m.getClass().getSimpleName(), dm.getClass().getSimpleName())
+                    .containsAll(versions);
+            assertThat(m.getVersions().keySet()).containsOnlyElementsOf(versions);
+        });
+    }
+}

--- a/rre-core/src/test/resources/engine_evaluation_tests/ratings/ratings_example.json
+++ b/rre-core/src/test/resources/engine_evaluation_tests/ratings/ratings_example.json
@@ -1,0 +1,73 @@
+{
+  "index": "basses",
+  "corpora_file": "electric_basses.bulk",
+  "id_field": "_id",
+  "topics": [
+    {
+      "description": "Fender basses",
+      "query_groups": [
+        {
+          "name": "Brand search",
+          "description": "The group tests several searches on the Fender brand",
+          "queries": [
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "fender"
+              }
+            },
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "Fender"
+              }
+            },
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "Fender bass"
+              }
+            }
+          ],
+          "relevant_documents": {
+            "1": {
+              "gain": 3
+            },
+            "2": {
+              "gain": 3
+            }
+          }
+        },
+        {
+          "name": "Jazz bass search",
+          "description": "Several searches on a given model (Jazz bass)",
+          "queries": [
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "jazz"
+              }
+            },
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "Jazz"
+              }
+            },
+            {
+              "template": "no_filtered_query_shape.json",
+              "placeholders": {
+                "$query": "Jazz Bass"
+              }
+            }
+          ],
+          "relevant_documents": {
+            "1": {
+              "gain": 3
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/rre-core/src/test/resources/engine_evaluation_tests/templates/no_filtered_query_shape.json
+++ b/rre-core/src/test/resources/engine_evaluation_tests/templates/no_filtered_query_shape.json
@@ -1,0 +1,10 @@
+{
+  "query": {
+    "match": {
+      "name": {
+        "query": "$query",
+        "minimum_should_match": "3<-75% 9<-85%"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This patch adds some changes and unit tests to ensure that all of the metrics are available at every level of the Evaluation tree - I believe that the asynchronous evaluations were causing concurrent modifications that caused this to fail on infrequent occasions.

The tests also raised a situation where sometimes the AsynchronousQueryEvaluationManager would start running and become stuck, so there is also a fix for this.

Any feedback would be welcome - the changes in DomainMember feel a bit awkward, but without them, metrics were getting lost about 20% of the time. I'm not sure if there's a better general approach to fixing this issue.