### PR TITLE
#127: Implement ES index name overrides.

### DIFF
--- a/rre-search-platform/rre-search-platform-elastic-search-impl/src/test/java/io/sease/rre/search/api/impl/ExternalElasticSearchIT.java
+++ b/rre-search-platform/rre-search-platform-elastic-search-impl/src/test/java/io/sease/rre/search/api/impl/ExternalElasticSearchIT.java
@@ -54,157 +54,157 @@ import static org.junit.Assert.assertTrue;
  */
 public class ExternalElasticSearchIT {
 
-	private static final String ELASTICSEARCH_CONTAINER_BASE = "docker.elastic.co/elasticsearch/elasticsearch";
-	private static final String DEFAULT_ELASTICSEARCH_VERSION = "7.5.0";
+    private static final String ELASTICSEARCH_CONTAINER_BASE = "docker.elastic.co/elasticsearch/elasticsearch";
+    private static final String DEFAULT_ELASTICSEARCH_VERSION = "7.5.0";
 
-	private static final String INDEX_NAME = "test";
-	private static final String INDEX_VERSION = "v1.0";
+    private static final String INDEX_NAME = "test";
+    private static final String INDEX_VERSION = "v1.0";
 
-	private static final DockerImageName DOCKER_IMAGE = DockerImageName.parse(ELASTICSEARCH_CONTAINER_BASE + ":" + System.getProperty("elasticsearch.version", DEFAULT_ELASTICSEARCH_VERSION));
+    private static final DockerImageName DOCKER_IMAGE = DockerImageName.parse(ELASTICSEARCH_CONTAINER_BASE + ":" + System.getProperty("elasticsearch.version", DEFAULT_ELASTICSEARCH_VERSION));
 
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
-	private SearchPlatform platform;
+    private SearchPlatform platform;
 
-	@Before
-	public void setupPlatform() {
-		platform = new ExternalElasticsearch();
-	}
+    @Before
+    public void setupPlatform() {
+        platform = new ExternalElasticsearch();
+    }
 
-	@Test
-	public void checkCollection_returnsFalseWhenNotLoaded() throws Exception {
-		final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
-		es.start();
+    @Test
+    public void checkCollection_returnsFalseWhenNotLoaded() throws Exception {
+        final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
+        es.start();
 
-		final File settingsFile = tempFolder.newFile("ccrf_settings.json");
-		FileWriter fw = new FileWriter(settingsFile);
-		fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ]}");
-		fw.close();
+        final File settingsFile = tempFolder.newFile("ccrf_settings.json");
+        FileWriter fw = new FileWriter(settingsFile);
+        fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ]}");
+        fw.close();
 
-		platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
+        platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
 
-		assertFalse(platform.checkCollection(INDEX_NAME, INDEX_VERSION));
-		es.close();
-	}
+        assertFalse(platform.checkCollection(INDEX_NAME, INDEX_VERSION));
+        es.close();
+    }
 
-	@Test
-	public void checkCollection_returnsTrueWhenAvailable() throws Exception {
-		final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
-		es.start();
+    @Test
+    public void checkCollection_returnsTrueWhenAvailable() throws Exception {
+        final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
+        es.start();
 
-		// Create an index
-		final RestHighLevelClient hlClient = new RestHighLevelClient(RestClient.builder(HttpHost.create(es.getHttpHostAddress())));
-		hlClient.indices().create(new CreateIndexRequest(INDEX_NAME), RequestOptions.DEFAULT);
+        // Create an index
+        final RestHighLevelClient hlClient = new RestHighLevelClient(RestClient.builder(HttpHost.create(es.getHttpHostAddress())));
+        hlClient.indices().create(new CreateIndexRequest(INDEX_NAME), RequestOptions.DEFAULT);
 
-		final File settingsFile = tempFolder.newFile("ccrt_settings.json");
-		FileWriter fw = new FileWriter(settingsFile);
-		fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ]}");
-		fw.close();
+        final File settingsFile = tempFolder.newFile("ccrt_settings.json");
+        FileWriter fw = new FileWriter(settingsFile);
+        fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ]}");
+        fw.close();
 
-		platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
+        platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
 
-		assertTrue(platform.checkCollection(INDEX_NAME, INDEX_VERSION));
-		hlClient.close();
-		es.close();
-	}
+        assertTrue(platform.checkCollection(INDEX_NAME, INDEX_VERSION));
+        hlClient.close();
+        es.close();
+    }
 
-	@Test
-	public void checkCollection_allowsIndexOverride() throws Exception {
-		final String overrideIndex = "override";
+    @Test
+    public void checkCollection_allowsIndexOverride() throws Exception {
+        final String overrideIndex = "override";
 
-		final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
-		es.start();
+        final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
+        es.start();
 
-		// Create an index
-		final RestHighLevelClient hlClient = new RestHighLevelClient(RestClient.builder(HttpHost.create(es.getHttpHostAddress())));
-		hlClient.indices().create(new CreateIndexRequest(overrideIndex), RequestOptions.DEFAULT);
+        // Create an index
+        final RestHighLevelClient hlClient = new RestHighLevelClient(RestClient.builder(HttpHost.create(es.getHttpHostAddress())));
+        hlClient.indices().create(new CreateIndexRequest(overrideIndex), RequestOptions.DEFAULT);
 
-		final File settingsFile = tempFolder.newFile("ccaio_settings.json");
-		FileWriter fw = new FileWriter(settingsFile);
-		fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ], \"index\": \"" + overrideIndex + "\" }");
-		fw.close();
+        final File settingsFile = tempFolder.newFile("ccaio_settings.json");
+        FileWriter fw = new FileWriter(settingsFile);
+        fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ], \"index\": \"" + overrideIndex + "\" }");
+        fw.close();
 
-		platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
+        platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
 
-		assertTrue(platform.checkCollection(INDEX_NAME, INDEX_VERSION));
-		hlClient.close();
-		es.close();
-	}
+        assertTrue(platform.checkCollection(INDEX_NAME, INDEX_VERSION));
+        hlClient.close();
+        es.close();
+    }
 
 
-	@Test
-	public void executeQuery_returnsResults() throws Exception {
-		final String overrideIndex = "override";
+    @Test
+    public void executeQuery_returnsResults() throws Exception {
+        final String overrideIndex = "override";
 
-		final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
-		es.start();
+        final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
+        es.start();
 
-		// Create the default index
-		final RestHighLevelClient hlClient = new RestHighLevelClient(RestClient.builder(HttpHost.create(es.getHttpHostAddress())));
-		hlClient.indices().create(new CreateIndexRequest(INDEX_NAME), RequestOptions.DEFAULT);
+        // Create the default index
+        final RestHighLevelClient hlClient = new RestHighLevelClient(RestClient.builder(HttpHost.create(es.getHttpHostAddress())));
+        hlClient.indices().create(new CreateIndexRequest(INDEX_NAME), RequestOptions.DEFAULT);
 
-		// Add some docs to the index
-		final Map<String, Object> source = new HashMap<>();
-		source.put("title", "Test");
-		hlClient.index(new IndexRequest(INDEX_NAME).id("1").source(source), RequestOptions.DEFAULT);
-		hlClient.index(new IndexRequest(INDEX_NAME).id("2").source(source), RequestOptions.DEFAULT);
-		hlClient.index(
-				new IndexRequest(INDEX_NAME).id("3").source(source).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
-				RequestOptions.DEFAULT);
+        // Add some docs to the index
+        final Map<String, Object> source = new HashMap<>();
+        source.put("title", "Test");
+        hlClient.index(new IndexRequest(INDEX_NAME).id("1").source(source), RequestOptions.DEFAULT);
+        hlClient.index(new IndexRequest(INDEX_NAME).id("2").source(source), RequestOptions.DEFAULT);
+        hlClient.index(
+                new IndexRequest(INDEX_NAME).id("3").source(source).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
+                RequestOptions.DEFAULT);
 
-		final File settingsFile = tempFolder.newFile("eq_settings.json");
-		FileWriter fw = new FileWriter(settingsFile);
-		fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ]}");
-		fw.close();
+        final File settingsFile = tempFolder.newFile("eq_settings.json");
+        FileWriter fw = new FileWriter(settingsFile);
+        fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ]}");
+        fw.close();
 
-		platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
+        platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
 
-		final QueryOrSearchResponse response = platform.executeQuery(INDEX_NAME, INDEX_VERSION, "{ \"query\": { \"match_all\": {} }}", source.keySet().toArray(new String[0]), 10);
+        final QueryOrSearchResponse response = platform.executeQuery(INDEX_NAME, INDEX_VERSION, "{ \"query\": { \"match_all\": {} }}", source.keySet().toArray(new String[0]), 10);
 
-		assertEquals(3, response.totalHits());
+        assertEquals(3, response.totalHits());
 
-		hlClient.close();
-		es.close();
-	}
+        hlClient.close();
+        es.close();
+    }
 
-	@Test
-	public void executeQuery_allowsIndexOverride() throws Exception {
-		final String overrideIndex = "override";
+    @Test
+    public void executeQuery_allowsIndexOverride() throws Exception {
+        final String overrideIndex = "override";
 
-		final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
-		es.start();
+        final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
+        es.start();
 
-		// Create the default index
-		final RestHighLevelClient hlClient = new RestHighLevelClient(RestClient.builder(HttpHost.create(es.getHttpHostAddress())));
-		hlClient.indices().create(new CreateIndexRequest(INDEX_NAME), RequestOptions.DEFAULT);
+        // Create the default index
+        final RestHighLevelClient hlClient = new RestHighLevelClient(RestClient.builder(HttpHost.create(es.getHttpHostAddress())));
+        hlClient.indices().create(new CreateIndexRequest(INDEX_NAME), RequestOptions.DEFAULT);
 
-		// Create an override index
-		hlClient.indices().create(new CreateIndexRequest(overrideIndex), RequestOptions.DEFAULT);
+        // Create an override index
+        hlClient.indices().create(new CreateIndexRequest(overrideIndex), RequestOptions.DEFAULT);
 
-		// Add some docs to the base index
-		final Map<String, Object> source = new HashMap<>();
-		source.put("title", "Test");
-		hlClient.index(new IndexRequest(INDEX_NAME).id("1").source(source), RequestOptions.DEFAULT);
+        // Add some docs to the base index
+        final Map<String, Object> source = new HashMap<>();
+        source.put("title", "Test");
+        hlClient.index(new IndexRequest(INDEX_NAME).id("1").source(source), RequestOptions.DEFAULT);
 
-		// Add a different number of docs to the override index
-		hlClient.index(new IndexRequest(overrideIndex).id("1").source(source), RequestOptions.DEFAULT);
-		hlClient.index(
-				new IndexRequest(overrideIndex).id("2").source(source).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
-				RequestOptions.DEFAULT);
+        // Add a different number of docs to the override index
+        hlClient.index(new IndexRequest(overrideIndex).id("1").source(source), RequestOptions.DEFAULT);
+        hlClient.index(
+                new IndexRequest(overrideIndex).id("2").source(source).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
+                RequestOptions.DEFAULT);
 
-		final File settingsFile = tempFolder.newFile("eqaio_settings.json");
-		FileWriter fw = new FileWriter(settingsFile);
-		fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ], \"index\": \"" + overrideIndex + "\" }");
-		fw.close();
+        final File settingsFile = tempFolder.newFile("eqaio_settings.json");
+        FileWriter fw = new FileWriter(settingsFile);
+        fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ], \"index\": \"" + overrideIndex + "\" }");
+        fw.close();
 
-		platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
+        platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
 
-		final QueryOrSearchResponse response = platform.executeQuery(INDEX_NAME, INDEX_VERSION, "{ \"query\": { \"match_all\": {} }}", source.keySet().toArray(new String[0]), 10);
+        final QueryOrSearchResponse response = platform.executeQuery(INDEX_NAME, INDEX_VERSION, "{ \"query\": { \"match_all\": {} }}", source.keySet().toArray(new String[0]), 10);
 
-		assertEquals(2, response.totalHits());
+        assertEquals(2, response.totalHits());
 
-		hlClient.close();
-		es.close();
-	}
+        hlClient.close();
+        es.close();
+    }
 }

--- a/rre-search-platform/rre-search-platform-elastic-search-impl/src/test/java/io/sease/rre/search/api/impl/ExternalElasticSearchIT.java
+++ b/rre-search-platform/rre-search-platform-elastic-search-impl/src/test/java/io/sease/rre/search/api/impl/ExternalElasticSearchIT.java
@@ -16,8 +16,11 @@
  */
 package io.sease.rre.search.api.impl;
 
+import io.sease.rre.search.api.QueryOrSearchResponse;
 import io.sease.rre.search.api.SearchPlatform;
 import org.apache.http.HttpHost;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -31,7 +34,10 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.util.HashMap;
+import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -48,8 +54,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class ExternalElasticSearchIT {
 
-	private static String ELASTICSEARCH_CONTAINER_BASE = "docker.elastic.co/elasticsearch/elasticsearch";
-	private static String DEFAULT_ELASTICSEARCH_VERSION = "7.5.0";
+	private static final String ELASTICSEARCH_CONTAINER_BASE = "docker.elastic.co/elasticsearch/elasticsearch";
+	private static final String DEFAULT_ELASTICSEARCH_VERSION = "7.5.0";
 
 	private static final String INDEX_NAME = "test";
 	private static final String INDEX_VERSION = "v1.0";
@@ -62,7 +68,7 @@ public class ExternalElasticSearchIT {
 	private SearchPlatform platform;
 
 	@Before
-	public void setupPlatform() throws Exception {
+	public void setupPlatform() {
 		platform = new ExternalElasticsearch();
 	}
 
@@ -103,4 +109,102 @@ public class ExternalElasticSearchIT {
 		es.close();
 	}
 
+	@Test
+	public void checkCollection_allowsIndexOverride() throws Exception {
+		final String overrideIndex = "override";
+
+		final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
+		es.start();
+
+		// Create an index
+		final RestHighLevelClient hlClient = new RestHighLevelClient(RestClient.builder(HttpHost.create(es.getHttpHostAddress())));
+		hlClient.indices().create(new CreateIndexRequest(overrideIndex), RequestOptions.DEFAULT);
+
+		final File settingsFile = tempFolder.newFile("ccaio_settings.json");
+		FileWriter fw = new FileWriter(settingsFile);
+		fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ], \"index\": \"" + overrideIndex + "\" }");
+		fw.close();
+
+		platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
+
+		assertTrue(platform.checkCollection(INDEX_NAME, INDEX_VERSION));
+		hlClient.close();
+		es.close();
+	}
+
+
+	@Test
+	public void executeQuery_returnsResults() throws Exception {
+		final String overrideIndex = "override";
+
+		final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
+		es.start();
+
+		// Create the default index
+		final RestHighLevelClient hlClient = new RestHighLevelClient(RestClient.builder(HttpHost.create(es.getHttpHostAddress())));
+		hlClient.indices().create(new CreateIndexRequest(INDEX_NAME), RequestOptions.DEFAULT);
+
+		// Add some docs to the index
+		final Map<String, Object> source = new HashMap<>();
+		source.put("title", "Test");
+		hlClient.index(new IndexRequest(INDEX_NAME).id("1").source(source), RequestOptions.DEFAULT);
+		hlClient.index(new IndexRequest(INDEX_NAME).id("2").source(source), RequestOptions.DEFAULT);
+		hlClient.index(
+				new IndexRequest(INDEX_NAME).id("3").source(source).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
+				RequestOptions.DEFAULT);
+
+		final File settingsFile = tempFolder.newFile("eq_settings.json");
+		FileWriter fw = new FileWriter(settingsFile);
+		fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ]}");
+		fw.close();
+
+		platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
+
+		final QueryOrSearchResponse response = platform.executeQuery(INDEX_NAME, INDEX_VERSION, "{ \"query\": { \"match_all\": {} }}", source.keySet().toArray(new String[0]), 10);
+
+		assertEquals(3, response.totalHits());
+
+		hlClient.close();
+		es.close();
+	}
+
+	@Test
+	public void executeQuery_allowsIndexOverride() throws Exception {
+		final String overrideIndex = "override";
+
+		final ElasticsearchContainer es = new ElasticsearchContainer(DOCKER_IMAGE);
+		es.start();
+
+		// Create the default index
+		final RestHighLevelClient hlClient = new RestHighLevelClient(RestClient.builder(HttpHost.create(es.getHttpHostAddress())));
+		hlClient.indices().create(new CreateIndexRequest(INDEX_NAME), RequestOptions.DEFAULT);
+
+		// Create an override index
+		hlClient.indices().create(new CreateIndexRequest(overrideIndex), RequestOptions.DEFAULT);
+
+		// Add some docs to the base index
+		final Map<String, Object> source = new HashMap<>();
+		source.put("title", "Test");
+		hlClient.index(new IndexRequest(INDEX_NAME).id("1").source(source), RequestOptions.DEFAULT);
+
+		// Add a different number of docs to the override index
+		hlClient.index(new IndexRequest(overrideIndex).id("1").source(source), RequestOptions.DEFAULT);
+		hlClient.index(
+				new IndexRequest(overrideIndex).id("2").source(source).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
+				RequestOptions.DEFAULT);
+
+		final File settingsFile = tempFolder.newFile("eqaio_settings.json");
+		FileWriter fw = new FileWriter(settingsFile);
+		fw.write("{ \"hostUrls\": [ \"" + es.getHttpHostAddress() + "\" ], \"index\": \"" + overrideIndex + "\" }");
+		fw.close();
+
+		platform.load(null, settingsFile, INDEX_NAME, INDEX_VERSION);
+
+		final QueryOrSearchResponse response = platform.executeQuery(INDEX_NAME, INDEX_VERSION, "{ \"query\": { \"match_all\": {} }}", source.keySet().toArray(new String[0]), 10);
+
+		assertEquals(2, response.totalHits());
+
+		hlClient.close();
+		es.close();
+	}
 }


### PR DESCRIPTION
This PR adds the ability to override the external Elasticsearch index by specifying the alternative in the configuration file.

(The Maven archetype for the external ES connector already had the indexName property present in the config. I'm not sure why the override wasn't implemented at the time.)

If merged, I'll modify the wiki pages as necessary.