### PR TITLE
#128: Implement collection overrides for external Solr:

### DIFF
--- a/rre-search-platform/rre-search-platform-external-solr-impl/src/test/java/io/sease/rre/search/api/impl/SolrClientManagerTest.java
+++ b/rre-search-platform/rre-search-platform-external-solr-impl/src/test/java/io/sease/rre/search/api/impl/SolrClientManagerTest.java
@@ -61,7 +61,7 @@ public class SolrClientManagerTest {
     @Test
     public void buildsHttpSolrClientForSingleHost() {
         ExternalApacheSolr.SolrSettings settings = new ExternalApacheSolr.SolrSettings(
-                Collections.singletonList("http://localhost:8983/solr"), null, null, null, null);
+                Collections.singletonList("http://localhost:8983/solr"), null, null, null, null, null);
 
         clientManager.buildSolrClient(TARGET_INDEX, settings);
 
@@ -83,7 +83,7 @@ public class SolrClientManagerTest {
                 .map(jsr -> "http://localhost:" + jsr.getLocalPort() + "/solr")
                 .collect(Collectors.toList());
 
-        ExternalApacheSolr.SolrSettings settings = new ExternalApacheSolr.SolrSettings(baseUrls, null, null, null, null);
+        ExternalApacheSolr.SolrSettings settings = new ExternalApacheSolr.SolrSettings(baseUrls, null, null, null, null, null);
 
         clientManager.buildSolrClient(TARGET_INDEX, settings);
 
@@ -96,7 +96,7 @@ public class SolrClientManagerTest {
     @Test
     public void buildsCloudSolrClientForZkHosts() {
         ExternalApacheSolr.SolrSettings settings = new ExternalApacheSolr.SolrSettings(
-                null, asList("localhost:2181", "localhost:2182"), null, null, null);
+                null, null, asList("localhost:2181", "localhost:2182"), null, null, null);
 
         clientManager.buildSolrClient(TARGET_INDEX, settings);
 

--- a/rre-search-platform/rre-search-platform-external-solr-impl/src/test/java/io/sease/rre/search/api/impl/SolrSettingsTest.java
+++ b/rre-search-platform/rre-search-platform-external-solr-impl/src/test/java/io/sease/rre/search/api/impl/SolrSettingsTest.java
@@ -22,7 +22,9 @@ import org.junit.Test;
 import java.io.InputStream;
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for the Solr settings.
@@ -69,12 +71,12 @@ public class SolrSettingsTest {
 
     @Test(expected=java.lang.IllegalArgumentException.class)
     public void constructorThrowsException_whenNoURLsSet() {
-        new ExternalApacheSolr.SolrSettings(null, null, null, null, null);
+        new ExternalApacheSolr.SolrSettings(null, null, null, null, null, null);
     }
 
     @Test
     public void canConstructWithZkHostsOnly() {
-        ExternalApacheSolr.SolrSettings settings = new ExternalApacheSolr.SolrSettings(null, Collections.singletonList("localhost:2181"), null, null, null);
+        ExternalApacheSolr.SolrSettings settings = new ExternalApacheSolr.SolrSettings(null, null, Collections.singletonList("localhost:2181"), null, null, null);
         assertNotNull(settings);
         assertTrue(settings.hasZookeeperSettings());
     }


### PR DESCRIPTION
This PR adds the ability to override the external Solr collection by specifying the alternative in the configuration file.

(The Maven archetype for the external Solr connector already had the collectionName property present in the config, but it was ignored. I'm not sure why the override wasn't implemented at the time.)

If merged, I'll modify the wiki pages as necessary.