### PR TITLE
Added pydantic validations and checks to rre-dataset-generator/src/model/document.py

### DIFF
--- a/rre-dataset-generator/src/model/document.py
+++ b/rre-dataset-generator/src/model/document.py
@@ -1,9 +1,27 @@
 from typing import Dict, Any
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, ValidationError
 
 class Document(BaseModel):
     """
     Represents a document with a unique identifier, and fields.
     """
-    id: str = Field(..., description="Unique identifier of the document.")
-    fields: Dict[str, Any] = Field(..., description="Fields of the document.")
+    id: str = Field(
+        ..., 
+        description="Unique identifier of the document.",
+        min_length=1
+    )
+    fields: Dict[str, Any] = Field(
+        ..., 
+        description="Fields of the document."
+    )
+
+    @field_validator('fields')
+    @classmethod
+    def check_no_empty_fields(cls, v: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate that the fields dictionary is not empty and its keys are not empty."""
+        if not v:
+            raise ValueError('The fields dictionary cannot be empty.')
+        if any(not key for key in v.keys()):
+            raise ValueError('Field keys cannot be empty strings.')
+        return v
+


### PR DESCRIPTION
Tested cases:

1. Valid Document: Tests creation with valid id and fields  
   - Valid: id="doc1", fields={"title": "Test Document"}

2. Empty ID Validation: Ensures id cannot be empty string  
   - Invalid: id="", fields={"title": "Test"}  
   - Expected: Raises ValidationError for string length

3. Empty Fields Validation: Ensures fields dict is not empty  
   - Invalid: id="doc2", fields={}  
   - Expected: Raises "The fields dictionary cannot be empty"

4. Empty Field Key Validation: Ensures no empty string keys in fields  
   - Invalid: id="doc3", fields={"": "value"}  
   - Expected: Raises "Field keys cannot be empty strings"

5. None Fields Validation: Ensures fields is not None  
   - Invalid: id="doc4", fields=None  
   - Expected: Raises "Input should be a valid dictionary"

6. Nested Fields Support: Validates complex nested structures  
   - Valid: id="doc5", fields={"metadata": {"author": "test"}, "tags": ["test", "document"]}
