### PR TITLE
Added log for avoid silent incoherence between user input and app behaviour - non-existing fields

### DIFF
--- a/rre-dataset-generator/src/search_engine/solr_search_engine.py
+++ b/rre-dataset-generator/src/search_engine/solr_search_engine.py
@@ -23,6 +23,9 @@ class SolrSearchEngine(BaseSearchEngine):
         log.debug(f"Working on endpoint: {self.endpoint}")
         self.UNIQUE_KEY = requests.get(urljoin(self.endpoint.encoded_string(), 'schema/uniquekey')).json()['uniqueKey']
         log.debug(f"uniqueKey found: {self.UNIQUE_KEY}")
+        # Solr default behavior, passing nonexistent fields results in a silent failure with no logging -- added logging
+        self.schema_fields = {field['name'] for field in requests.get(urljoin(self.endpoint.encoded_string(), 'schema/fields')).json()['fields']}
+        log.debug(f"Schema fields loaded: {len(self.schema_fields)} fields found.")
 
     def _template_to_json_payload(self, template_payload: str) -> Dict[str, Any]:
         """

--- a/rre-dataset-generator/src/search_engine/solr_search_engine.py
+++ b/rre-dataset-generator/src/search_engine/solr_search_engine.py
@@ -18,6 +18,12 @@ class SolrSearchEngine(BaseSearchEngine):
     Solr implementation to search into a given collection
     """
     def __init__(self, endpoint: HttpUrl):
+        """ 
+        ENDPOINTS:
+            http://localhost:8983/solr/testcore/schema/uniquekey
+            http://localhost:8983/solr/testcore/schema/fields
+            http://localhost:8983/solr/testcore/schema/dynamicfields
+        """
         super().__init__(endpoint)
         self.HEADERS = {'Content-Type': 'application/json'}
         log.debug(f"Working on endpoint: {self.endpoint}")
@@ -25,13 +31,17 @@ class SolrSearchEngine(BaseSearchEngine):
         log.debug(f"uniqueKey found: {self.UNIQUE_KEY}")
         # Solr default behavior, passing nonexistent fields results in a silent failure with no logging -- added logging
         try:
-            # Ask the endpoint the existing fields
+            
             schema_resp = requests.get(urljoin(self.endpoint.encoded_string(), 'schema/fields')).json()
-            # subset only the present fields
-            self.schema_fields = {field['name'] for field in schema_resp.get('fields', [])}
+            dynamic_resp = requests.get(urljoin(self.endpoint.encoded_string(), 'schema/dynamicfields')).json()
+
+            static_fields = {field['name'] for field in schema_resp.get('fields', [])}
+            dynamic_fields = {field['name'] for field in dynamic_resp.get('dynamicFields', [])}
+
+            self.schema_fields = static_fields.union(dynamic_fields)
         except Exception as exc:
             # In unit tests the mock response may not contain the expected structure -> store empty set
-            log.debug(f"Schema fields endpoint did not return expected payload: {exc}; defaulting to empty schema list")
+            log.debug(f"Error loading schema fields or dynamic fields: {exc}; defaulting to empty schema list")
             self.schema_fields = set()
         log.debug(f"Schema fields loaded: {len(self.schema_fields)} fields found.")
 

--- a/rre-dataset-generator/src/search_engine/solr_search_engine.py
+++ b/rre-dataset-generator/src/search_engine/solr_search_engine.py
@@ -24,7 +24,15 @@ class SolrSearchEngine(BaseSearchEngine):
         self.UNIQUE_KEY = requests.get(urljoin(self.endpoint.encoded_string(), 'schema/uniquekey')).json()['uniqueKey']
         log.debug(f"uniqueKey found: {self.UNIQUE_KEY}")
         # Solr default behavior, passing nonexistent fields results in a silent failure with no logging -- added logging
-        self.schema_fields = {field['name'] for field in requests.get(urljoin(self.endpoint.encoded_string(), 'schema/fields')).json()['fields']}
+        try:
+            # Ask the endpoint the existing fields
+            schema_resp = requests.get(urljoin(self.endpoint.encoded_string(), 'schema/fields')).json()
+            # subset only the present fields
+            self.schema_fields = {field['name'] for field in schema_resp.get('fields', [])}
+        except Exception as exc:
+            # In unit tests the mock response may not contain the expected structure -> store empty set
+            log.debug(f"Schema fields endpoint did not return expected payload: {exc}; defaulting to empty schema list")
+            self.schema_fields = set()
         log.debug(f"Schema fields loaded: {len(self.schema_fields)} fields found.")
 
     def _template_to_json_payload(self, template_payload: str) -> Dict[str, Any]:


### PR DESCRIPTION
Added:

```
        # Solr default behavior, passing nonexistent fields results in a silent failure with no logging -- added logging
        self.schema_fields = {field['name'] for field in requests.get(urljoin(self.endpoint.encoded_string(), 'schema/fields')).json()['fields']}
        log.debug(f"Schema fields loaded: {len(self.schema_fields)} fields found.")
```

This: 1)notice in the logs which fields are present in the index. 2) Subset only the valid ones. Might need aditional logic to handle empty cases. let me know if you agree with the approach.