### PR TITLE
DAGE-31: M3 index doc to solr with embeddings

### DIFF
--- a/rre-dataset-generator/tests/integration/docker-compose.solr.yml
+++ b/rre-dataset-generator/tests/integration/docker-compose.solr.yml
@@ -4,12 +4,17 @@ services:
     container_name: solr_test
     ports:
       - "8983:8983"
-    command: ["solr-precreate", "testcore"]
+    command:
+      - solr-precreate
+      - testcore
 
   solr-init:
     build:
       context: solr-init
     depends_on:
       - solr
+    volumes:
+      - ./solr-init/data/dataset.json:/opt/rre-dataset-generator/data/dataset.json
+      - ../../output/embeddings:/opt/rre-dataset-generator/embeddings
+    working_dir: /opt/rre-dataset-generator
     command: ["sh", "-c", "/opt/rre-dataset-generator/solr-init.sh"]
-

--- a/rre-dataset-generator/tests/integration/docker-compose.solr.yml
+++ b/rre-dataset-generator/tests/integration/docker-compose.solr.yml
@@ -4,15 +4,22 @@ services:
     container_name: solr_test
     ports:
       - "8983:8983"
-    command:
-      - solr-precreate
-      - testcore
+    command: ["solr-precreate", "testcore"]
+
+  prepare-embeddings-dir:
+    build:
+      context: solr-init
+    command: ["sh", "-c", "mkdir", "-p", "/workspace/output/embeddings"]
+    volumes:
+      - ./:/workspace
+    restart: "no"
 
   solr-init:
     build:
       context: solr-init
     depends_on:
       - solr
+      - prepare-embeddings-dir
     volumes:
       - ./solr-init/data/dataset.json:/opt/rre-dataset-generator/data/dataset.json
       - ../../output/embeddings:/opt/rre-dataset-generator/embeddings

--- a/rre-dataset-generator/tests/integration/solr-init/Dockerfile
+++ b/rre-dataset-generator/tests/integration/solr-init/Dockerfile
@@ -1,4 +1,5 @@
-FROM curlimages/curl:8.14.1
+FROM alpine:3.18
 
-COPY data/dataset.json /opt/rre-dataset-generator/data/dataset.json
+RUN apk add --no-cache curl jq
+
 COPY --chmod=777 solr-init.sh /opt/rre-dataset-generator/solr-init.sh

--- a/rre-dataset-generator/tests/integration/solr-init/Dockerfile
+++ b/rre-dataset-generator/tests/integration/solr-init/Dockerfile
@@ -3,3 +3,4 @@ FROM alpine:3.22.1
 RUN apk add --no-cache curl jq
 
 COPY --chmod=777 solr-init.sh /opt/rre-dataset-generator/solr-init.sh
+RUN mkdir -p /opt/rre-dataset-generator/embeddings

--- a/rre-dataset-generator/tests/integration/solr-init/Dockerfile
+++ b/rre-dataset-generator/tests/integration/solr-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.22.1
 
 RUN apk add --no-cache curl jq
 

--- a/rre-dataset-generator/tests/integration/solr-init/solr-init.sh
+++ b/rre-dataset-generator/tests/integration/solr-init/solr-init.sh
@@ -57,11 +57,11 @@ else
 fi
 
 if [ "$COUNT_FOUND" -eq 0 ]; then
-  echo "[INFO] Indexing into Solr…"
+  echo "[INFO] Indexing dataset…";
   curl -f -X POST \
        -H "Content-Type: application/json" \
        --data-binary @"$TMP_FILE" \
-       "$COLLECTION_ENDPOINT/update?commit=true"
+       $COLLECTION_ENDPOINT/update?commit=true;
   echo "[INFO] Done indexing.";
 else
   echo "[INFO] Collection already contains data, skipping indexing.";

--- a/rre-dataset-generator/tests/integration/solr-init/solr-init.sh
+++ b/rre-dataset-generator/tests/integration/solr-init/solr-init.sh
@@ -6,7 +6,7 @@ DATASET_FILE="/opt/rre-dataset-generator/data/dataset.json";
 EMBEDDINGS_FILE="/opt/rre-dataset-generator/embeddings/doc_embeddings.jsonl";
 TMP_FILE="/tmp/merged_dataset.json";
 
-echo "[INFO] Waiting for Solr core '\''testcore'\'' to be ready…";
+echo "[INFO] Waiting for Solr core \"testcore\" to be ready…";
 max=30;
 for i in $(seq 1 $max); do
   if curl -sf $COLLECTION_ENDPOINT/admin/ping?wt=json > /dev/null; then
@@ -23,34 +23,36 @@ if ! curl -sf $COLLECTION_ENDPOINT/admin/ping?wt=json > /dev/null; then
   exit 1;
 fi
 
-curl -f -X POST -H 'Content-type:application/json' --data-binary '{
-  "add-field-type" : {
-      "name":"knn_vector_10",
-      "class":"solr.DenseVectorField",
-      "vectorDimension":10,
-      "similarityFunction":"cosine",
-      "knnAlgorithm":"hnsw"
-    },
-  "add-field" : {
-      "name":"vector",
-      "type":"knn_vector_10",
-      "indexed":true,
-      "stored":true
-    }
-  }' "$COLLECTION_ENDPOINT/schema"
-
 SOLR_RESPONSE=$(curl -sf $COLLECTION_ENDPOINT/select\?q\=\*:\*)
 COUNT_FOUND=$(echo "$SOLR_RESPONSE" | { grep -cE '"numFound":[1-9]+' || test $? = 1; })
 echo "num found: $COUNT_FOUND"
 
 if [ -f "$EMBEDDINGS_FILE" ] && command -v jq >/dev/null 2>&1; then
-  echo "[INFO] Embeddings file found and jq available → merging…"
+  VECTOR_DIM=$(head -n 1 "$EMBEDDINGS_FILE" | jq '.vector | length')
+  echo "[INFO] Embeddings file found -> detected embedding dimension: $VECTOR_DIM"
+  echo "[INFO] jq available → merging…"
   jq --slurpfile emb "$EMBEDDINGS_FILE" '
     map(. as $d | $emb[] | select(.id == $d.id) | $d + {vector: .vector}) as $with_vec
     | map(if ($with_vec[]? | select(.id == .id) | .id) == .id
           then ($with_vec[] | select(.id == .id))
           else . end)
   ' "$DATASET_FILE" > "$TMP_FILE"
+  echo "[INFO] Updating solr collection with vector field (dim=$VECTOR_DIM)…"
+  curl -f -X POST -H 'Content-type:application/json' --data-binary "{
+  \"add-field-type\" : {
+      \"name\":\"knn_vector\",
+      \"class\":\"solr.DenseVectorField\",
+      \"vectorDimension\":$VECTOR_DIM,
+      \"similarityFunction\":\"cosine\",
+      \"knnAlgorithm\":\"hnsw\"
+    },
+  \"add-field\" : {
+      \"name\":\"vector\",
+      \"type\":\"knn_vector\",
+      \"indexed\":true,
+      \"stored\":true
+    }
+  }" $COLLECTION_ENDPOINT/schema
 else
   echo "[INFO] Using plain dataset (no embeddings or jq missing)…"
   cp "$DATASET_FILE" "$TMP_FILE"

--- a/rre-dataset-generator/tests/integration/solr-init/solr-init.sh
+++ b/rre-dataset-generator/tests/integration/solr-init/solr-init.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 COLLECTION_ENDPOINT="http://solr:8983/solr/testcore";
+DATASET_FILE="/opt/rre-dataset-generator/data/dataset.json";
+EMBEDDINGS_FILE="/opt/rre-dataset-generator/embeddings/doc_embeddings.jsonl";
+TMP_FILE="/tmp/merged_dataset.json";
 
 echo "[INFO] Waiting for Solr core '\''testcore'\'' to be ready…";
 max=30;
@@ -20,16 +23,45 @@ if ! curl -sf $COLLECTION_ENDPOINT/admin/ping?wt=json > /dev/null; then
   exit 1;
 fi
 
+curl -f -X POST -H 'Content-type:application/json' --data-binary '{
+  "add-field-type" : {
+      "name":"knn_vector_10",
+      "class":"solr.DenseVectorField",
+      "vectorDimension":10,
+      "similarityFunction":"cosine",
+      "knnAlgorithm":"hnsw"
+    },
+  "add-field" : {
+      "name":"vector",
+      "type":"knn_vector_10",
+      "indexed":true,
+      "stored":true
+    }
+  }' "$COLLECTION_ENDPOINT/schema"
+
 SOLR_RESPONSE=$(curl -sf $COLLECTION_ENDPOINT/select\?q\=\*:\*)
 COUNT_FOUND=$(echo "$SOLR_RESPONSE" | { grep -cE '"numFound":[1-9]+' || test $? = 1; })
 echo "num found: $COUNT_FOUND"
 
+if [ -f "$EMBEDDINGS_FILE" ] && command -v jq >/dev/null 2>&1; then
+  echo "[INFO] Embeddings file found and jq available → merging…"
+  jq --slurpfile emb "$EMBEDDINGS_FILE" '
+    map(. as $d | $emb[] | select(.id == $d.id) | $d + {vector: .vector}) as $with_vec
+    | map(if ($with_vec[]? | select(.id == .id) | .id) == .id
+          then ($with_vec[] | select(.id == .id))
+          else . end)
+  ' "$DATASET_FILE" > "$TMP_FILE"
+else
+  echo "[INFO] Using plain dataset (no embeddings or jq missing)…"
+  cp "$DATASET_FILE" "$TMP_FILE"
+fi
+
 if [ "$COUNT_FOUND" -eq 0 ]; then
-  echo "[INFO] Indexing dataset…";
+  echo "[INFO] Indexing into Solr…"
   curl -f -X POST \
        -H "Content-Type: application/json" \
-       --data-binary @/opt/rre-dataset-generator/data/dataset.json \
-       $COLLECTION_ENDPOINT/update?commit=true;
+       --data-binary @"$TMP_FILE" \
+       "$COLLECTION_ENDPOINT/update?commit=true"
   echo "[INFO] Done indexing.";
 else
   echo "[INFO] Collection already contains data, skipping indexing.";

--- a/rre-dataset-generator/tests/integration/solr-init/solr-init.sh
+++ b/rre-dataset-generator/tests/integration/solr-init/solr-init.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 COLLECTION_ENDPOINT="http://solr:8983/solr/testcore";
 DATASET_FILE="/opt/rre-dataset-generator/data/dataset.json";
-EMBEDDINGS_FILE="/opt/rre-dataset-generator/embeddings/doc_embeddings.jsonl";
+EMBEDDINGS_FOLDER="/opt/rre-dataset-generator/embeddings";
+EMBEDDINGS_FILE="$EMBEDDINGS_FOLDER/doc_embeddings.jsonl";
 TMP_FILE="/tmp/merged_dataset.json";
 
 echo "[INFO] Waiting for Solr core \"testcore\" to be ready…";
@@ -27,16 +28,22 @@ SOLR_RESPONSE=$(curl -sf $COLLECTION_ENDPOINT/select\?q\=\*:\*)
 COUNT_FOUND=$(echo "$SOLR_RESPONSE" | { grep -cE '"numFound":[1-9]+' || test $? = 1; })
 echo "num found: $COUNT_FOUND"
 
+mkdir -p $EMBEDDINGS_FOLDER
+
 if [ -f "$EMBEDDINGS_FILE" ] && command -v jq >/dev/null 2>&1; then
   VECTOR_DIM=$(head -n 1 "$EMBEDDINGS_FILE" | jq '.vector | length')
   echo "[INFO] Embeddings file found -> detected embedding dimension: $VECTOR_DIM"
   echo "[INFO] jq available → merging…"
-  jq --slurpfile emb "$EMBEDDINGS_FILE" '
-    map(. as $d | $emb[] | select(.id == $d.id) | $d + {vector: .vector}) as $with_vec
-    | map(if ($with_vec[]? | select(.id == .id) | .id) == .id
-          then ($with_vec[] | select(.id == .id))
-          else . end)
-  ' "$DATASET_FILE" > "$TMP_FILE"
+  jq --slurpfile emb "$EMBEDDINGS_FILE" '       # parse the $EMBEDDINGS_FILE into the var `emb` and execute the following script
+  map(
+    . as $doc                                   # save each line of the document in the var `doc`
+    | ($emb[] | select(.id == $doc.id)) as $e   # assign to the var `e` the line of the emb file if it has the same id
+    | if $e != null
+      then $doc + {vector: $e.vector}           # appends the embedding to the document
+      else $doc                                 # otherwise it keeps just the fields
+      end
+  )
+' "$DATASET_FILE" > "$TMP_FILE"
   echo "[INFO] Updating solr collection with vector field (dim=$VECTOR_DIM)…"
   curl -f -X POST -H 'Content-type:application/json' --data-binary "{
   \"add-field-type\" : {


### PR DESCRIPTION
Jira ticket: https://sease.atlassian.net/browse/DAGE-31

Updated the docker-related files inside solr-init/ folder to deal with the file output/embeddings/doc_embeddings.jsonland index documents’ embeddings into the solr instance. For now the embedding dimension is fixed to 10, then it needs to be changed later on when we have a complete configuration file. The folder where the file containing the embeddings is fixed. If the folder is not found, then an image creates the folder needed but empty. In this way, the code works even if the file doesn’t exists, it just index the documents without any embedding.

