### PR TITLE
Dage 70: Fix solr compose

### DIFF
--- a/rre-tools/dataset-generator/README.md
+++ b/rre-tools/dataset-generator/README.md
@@ -104,6 +104,10 @@ This will start 2 services:
  - `solr`, available at http://localhost:8983/solr
  - `solr-init`, loads documents from solr-init/data/dataset.json.
 
+**Note:** for hygiene reasons we recommend building the `Solr` container without cache first:
+```bash
+docker-compose -f docker-compose.solr.yml build --no-cache
+```
 
 ##### Running OpenSearch (Single Node)
 

--- a/rre-tools/docker-services/docker-compose.solr.yml
+++ b/rre-tools/docker-services/docker-compose.solr.yml
@@ -9,7 +9,7 @@ services:
   prepare-embeddings-dir:
     build:
       context: solr-init
-    command: ["sh", "-c", "mkdir", "-p", "/workspace/resources/embeddings"]
+    command: ["sh","-c","mkdir -p /workspace/output/embeddings"]
     volumes:
       - ../resources:/workspace/resources
     restart: "no"

--- a/rre-tools/docker-services/docker-compose.solr.yml
+++ b/rre-tools/docker-services/docker-compose.solr.yml
@@ -9,7 +9,7 @@ services:
   prepare-embeddings-dir:
     build:
       context: solr-init
-    command: ["sh","-c","mkdir -p /workspace/output/embeddings"]
+    command: ["sh","-c","mkdir -p /workspace/resources/embeddings"]
     volumes:
       - ../resources:/workspace/resources
     restart: "no"


### PR DESCRIPTION
[PR: ](https://sease.atlassian.net/jira/software/projects/DAGE/boards/84?selectedIssue=DAGE-70)

Trying to fix the missmatch in the ratings on the [Quepid Bug task](https://sease.atlassian.net/browse/DAGE-68?atlOrigin=eyJpIjoiNDU1YjdkZDdhMDc3NDljZWEzNTBmMzM3ZTM4NzA3YjUiLCJwIjoiaiJ9), I've found another "silent" bug, in the last stage of the dataset-generator, which init the Solr Instance, but did not perform the indexing / config, due to a syntax problem. 

Note: also, I was running as usual -> With the new changes in the Dockerfile there's a version missmatch. Fixed by build without cache (added note to README.md)