### PR TITLE
DAGE-61: fixed var search_engine_collection_endpoint

### DIFF
--- a/rre-tools/dataset-generator/README.md
+++ b/rre-tools/dataset-generator/README.md
@@ -23,8 +23,8 @@ Create a `config.yaml` file in the root directory. This file controls the entire
 ```yaml
 query_template: "q=#$query##&fq=genre:horror&wt=json"
 search_engine_type: "solr"
-index_name: "testcore"
-search_engine_collection_endpoint: "http://localhost:8983/solr/mycore"
+collection_name: "testcore"
+search_engine_endpoint: "http://localhost:8983/solr/"
 documents_filter:
   - genre:
       - "horror"

--- a/rre-tools/dataset-generator/config.yaml
+++ b/rre-tools/dataset-generator/config.yaml
@@ -9,11 +9,11 @@ query_template: "q={!edismax qf=title^2 description mm=1}#$query##&rows=10&fl=id
 search_engine_type: "solr"
 
 # Name of the search engine index/collection
-index_name: "testcore"
+collection_name: "testcore"
 
 # Endpoint URL of the search engine collection or index
-# opensearch: http://localhost:9200/testcore
-search_engine_collection_endpoint: "http://localhost:8983/solr/testcore/"
+# opensearch: http://localhost:9200/
+search_engine_url: "http://localhost:8983/solr/"
 
 # (Optional) Filter query to restrict the set of documents used to generate queries.
 # If a field has more than one value, the documents retrieved have at least one of the values in the field (OR-

--- a/rre-tools/dataset-generator/src/dataset_generator/config.py
+++ b/rre-tools/dataset-generator/src/dataset_generator/config.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, HttpUrl, Field, field_validator, FilePath, model
 import yaml
 import logging
 from pathlib import Path
+from urllib.parse import urljoin
 
 from commons.model import WriterConfig
 
@@ -12,8 +13,8 @@ log = logging.getLogger(__name__)
 class Config(BaseModel):
     query_template: str = Field("q=#$query##", description="Template string for queries with a placeholder for keywords.")
     search_engine_type: Literal['solr', 'elasticsearch', 'opensearch', 'vespa']
-    index_name: str = Field(..., description="Name of the index/collection of the search engine")
-    search_engine_collection_endpoint: HttpUrl
+    collection_name: str = Field(..., description="Name of the index/collection of the search engine")
+    search_engine_url: HttpUrl
     documents_filter: Optional[List[Dict[str, List[str]]]] = Field(
         None,
         description="Optional list of filter conditions for documents"
@@ -37,7 +38,7 @@ class Config(BaseModel):
     def build_writer_config(self) -> WriterConfig:
         return WriterConfig(
             output_format = self.output_format,
-            index = self.index_name,
+            index = self.collection_name,
             id_field = self.id_field,
             query_template = self.rre_query_template,
             query_placeholder = self.rre_query_placeholder
@@ -86,6 +87,13 @@ class Config(BaseModel):
             error_msg = f"Unknown relevance scale: {self.relevance_scale}"
             log.error(error_msg)
             raise ValueError(error_msg)
+
+    @property
+    def search_engine_collection_endpoint(self) -> HttpUrl:
+        """
+        Returns the set of valid labels based on the relevance scale.
+        """
+        return HttpUrl(urljoin(self.search_engine_url.encoded_string() + "/", self.collection_name + "/"))
 
     @model_validator(mode="after")
     def check_rre_fields_required(self) -> "Config":

--- a/rre-tools/dataset-generator/tests/unit/resources/elasticsearch_good_config.yaml
+++ b/rre-tools/dataset-generator/tests/unit/resources/elasticsearch_good_config.yaml
@@ -7,8 +7,8 @@ query_template: >
         } 
     }
 search_engine_type: "elasticsearch"
-index_name: "testcore"
-search_engine_collection_endpoint: 'http://localhost:9200/testcore/'
+collection_name: "testcore"
+search_engine_url: 'http://localhost:9200/'
 doc_number: 100
 doc_fields:
   - "title"

--- a/rre-tools/dataset-generator/tests/unit/resources/good_config.yaml
+++ b/rre-tools/dataset-generator/tests/unit/resources/good_config.yaml
@@ -1,7 +1,7 @@
 query_template: "q=#$query##&fq=genre:horror&wt=json"
 search_engine_type: "solr"
-index_name: "testcore"
-search_engine_collection_endpoint: "http://localhost:8983/solr/testcore"
+collection_name: "testcore"
+search_engine_url: "http://localhost:8983/solr/"
 documents_filter:
   - genre:
       - "horror"

--- a/rre-tools/dataset-generator/tests/unit/resources/good_config_opensearch.yaml
+++ b/rre-tools/dataset-generator/tests/unit/resources/good_config_opensearch.yaml
@@ -10,8 +10,8 @@ query_template: >
     "size": 20
   }
 search_engine_type: "opensearch"
-index_name: "testcore"
-search_engine_collection_endpoint: "http://localhost:9200/testcore"
+collection_name: "testcore"
+search_engine_url: "http://localhost:9200/"
 doc_number: 20
 doc_fields:
   - "title"

--- a/rre-tools/dataset-generator/tests/unit/resources/invalid_type.yaml
+++ b/rre-tools/dataset-generator/tests/unit/resources/invalid_type.yaml
@@ -1,5 +1,5 @@
 search_engine_type: "solr"
-search_engine_collection_endpoint: "http://localhost"
+search_engine_url: "http://localhost"
 doc_number: "one hundred"  # Invalid type
 doc_fields: ["title"]
 num_queries_needed: 5

--- a/rre-tools/dataset-generator/tests/unit/resources/missing_optional.yaml
+++ b/rre-tools/dataset-generator/tests/unit/resources/missing_optional.yaml
@@ -1,7 +1,7 @@
 # Missing: query_template (optional)
 search_engine_type: "solr"
-index_name: "testcore"
-search_engine_collection_endpoint: "http://localhost"
+collection_name: "testcore"
+search_engine_url: "http://localhost"
 doc_number: 10
 doc_fields: ["title"]
 num_queries_needed: 5

--- a/rre-tools/dataset-generator/tests/unit/resources/missing_required.yaml
+++ b/rre-tools/dataset-generator/tests/unit/resources/missing_required.yaml
@@ -1,7 +1,7 @@
 # Missing: query_template
 search_engine_type: "solr"
-index_name: "testcore"
-# Missing: search_engine_collection_endpoint
+collection_name: "testcore"
+# Missing: search_engine_url
 doc_number: 100
 doc_fields: ["title"]
 num_queries_needed: 5

--- a/rre-tools/dataset-generator/tests/unit/resources/mteb_config.yaml
+++ b/rre-tools/dataset-generator/tests/unit/resources/mteb_config.yaml
@@ -1,7 +1,7 @@
 query_template: "q=#$query##&fq=genre:horror&wt=json"
 search_engine_type: "solr"
-index_name: "testcore"
-search_engine_collection_endpoint: "http://localhost:8983/solr/testcore/"
+collection_name: "testcore"
+search_engine_url: "http://localhost:8983/solr/"
 doc_number: 100
 doc_fields:
   - "title"

--- a/rre-tools/dataset-generator/tests/unit/resources/solr_good_config.yaml
+++ b/rre-tools/dataset-generator/tests/unit/resources/solr_good_config.yaml
@@ -1,7 +1,7 @@
 query_template: "q=#$query##&fq=genre:horror&wt=json"
 search_engine_type: "solr"
-index_name: "testcore"
-search_engine_collection_endpoint: "http://localhost:8983/solr/testcore/"
+collection_name: "testcore"
+search_engine_url: "http://localhost:8983/solr/"
 doc_number: 100
 doc_fields:
   - "title"

--- a/rre-tools/dataset-generator/tests/unit/test_config.py
+++ b/rre-tools/dataset-generator/tests/unit/test_config.py
@@ -14,7 +14,9 @@ def config(resource_folder):
 def test_good_config__expects__all_parameters_read(config):
     assert config.query_template == 'q=#$query##&fq=genre:horror&wt=json'
     assert config.search_engine_type == "solr"
-    assert config.search_engine_collection_endpoint == HttpUrl("http://localhost:8983/solr/testcore")
+    assert config.collection_name == "testcore"
+    assert config.search_engine_url == HttpUrl("http://localhost:8983/solr/")
+    assert config.search_engine_collection_endpoint == HttpUrl("http://localhost:8983/solr/testcore/")
     assert config.documents_filter == [
         {"genre": ["horror", "fantasy"]},
         {"type": ["book"]}
@@ -30,7 +32,6 @@ def test_good_config__expects__all_parameters_read(config):
     assert config.output_destination == Path("output")
     assert config.save_llm_explanation is True
     assert config.llm_explanation_destination == Path("output/rating_explanation.json")
-    assert config.index_name == "testcore"
 
 
 def test_missing_optional_field_values__expects__all_defaults_read(resource_folder):


### PR DESCRIPTION
DAGE-61: [Jira ticket](https://sease.atlassian.net/browse/DAGE-61)

Now that variable is built under the hood as a property of the pydantic model. This allows to minimal changes + standardization of the url.

Executed:
- ruff
- mypy
- unit tests
- main pipeline


