### PR TITLE
DAGE-71: Fix Path Building

### DIFF
--- a/rre-tools/commons/src/commons/data_store.py
+++ b/rre-tools/commons/src/commons/data_store.py
@@ -5,7 +5,6 @@ from typing import Dict, Optional, Tuple, List
 
 import json
 import logging
-import os
 from uuid import uuid4
 from pydantic import ValidationError
 from commons.model import Document, Query, Rating
@@ -152,7 +151,7 @@ class DataStore:
         }
         tmp_path = self.path.with_name(self.path.name + f".{uuid4().hex}.tmp")
         tmp_path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding=ENCODING)
-        os.replace(tmp_path, self.path)
+        tmp_path.replace(self.path)
         
     def load(self) -> None:
         if not self.path.exists():

--- a/rre-tools/commons/src/commons/writers/mteb_writer.py
+++ b/rre-tools/commons/src/commons/writers/mteb_writer.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from pathlib import Path
 
 from commons.data_store import DataStore
@@ -64,7 +63,7 @@ class MtebWriter(AbstractWriter):
             datastore: DataStore containing the data to write
         """
         path = Path(output_path)
-        os.makedirs(path, exist_ok=True)
+        path.mkdir(parents=True, exist_ok=True)
         try:
             self._write_corpus(path / "corpus.jsonl", datastore)
             log.info("Corpus written successfully")

--- a/rre-tools/commons/src/commons/writers/quepid_writer.py
+++ b/rre-tools/commons/src/commons/writers/quepid_writer.py
@@ -1,5 +1,4 @@
 import csv
-import os
 from pathlib import Path
 from typing import List, Tuple
 
@@ -28,7 +27,7 @@ class QuepidWriter(AbstractWriter):
     def write(self, output_path: str | Path, datastore: DataStore) -> None:
         """Writes queries and their scored documents to a CSV file in Quepid format."""
         output_path = Path(output_path) / QUEPID_OUTPUT_FILENAME
-        os.makedirs(output_path.parent, exist_ok=True)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
         with open(output_path, 'w', newline='') as csvfile:
             writer = csv.writer(csvfile)

--- a/rre-tools/commons/tests/unit/test_data_store.py
+++ b/rre-tools/commons/tests/unit/test_data_store.py
@@ -1,6 +1,5 @@
 import pytest
 from pathlib import Path
-import os
 import json
 import logging
 
@@ -108,7 +107,7 @@ def test_persistence__expects__save_and_load_roundtrip(tmp_db_path, doc_a, query
     query = ds1.add_query(query_q.text)
     ds1.create_rating_score(query.id, doc_a.id, 5)
     ds1.save()
-    assert os.path.exists(tmp_db_path)
+    assert tmp_db_path.exists()
 
     ds2 = DataStore(path=tmp_db_path)  # load() is called in __init__
     assert len(ds2.get_documents()) == 1

--- a/rre-tools/dataset-generator/src/dataset_generator/config.py
+++ b/rre-tools/dataset-generator/src/dataset_generator/config.py
@@ -105,7 +105,8 @@ class Config(BaseModel):
         :param config_path: Path to the YAML config file
         :return: Parsed and validated Config object
         """
-        with open(config_path, 'r') as f:
+        path = Path(config_path)
+        with path.open('r') as f:
             raw_config = yaml.safe_load(f)
 
         log.debug("Configuration file loaded successfully.")

--- a/rre-tools/dataset-generator/src/dataset_generator/main.py
+++ b/rre-tools/dataset-generator/src/dataset_generator/main.py
@@ -28,7 +28,7 @@ def setup_logging(verbose: bool = False) -> None:
 def add_user_queries(config: Config, data_store: DataStore) -> None:
     """Loads queries from file (if exists) and adds them as Query objects."""
     if config.queries is not None:
-        with open(config.queries, "r", encoding="utf-8") as file:
+        with config.queries.open("r", encoding="utf-8") as file:
             for line in file:
                 clean_line = line.strip()
                 if clean_line:


### PR DESCRIPTION
TASK: [DAGE-71]( https://sease.atlassian.net/browse/DAGE-71?atlOrigin=eyJpIjoiNjkxMjY4NmY5MzFlNDgyYzg1YTg5MjIyMGMxODAxZTIiLCJwIjoiaiJ9)

Path construction building unified for rre-tools (commons / dataset-generator) 
- Replace the os.path with Pathlib to ensure cross-plataform (Linux / Windows / MacOS)
- Replace the os.mkdir
- Ensure the config paths are defined and loaded as Paths, not strings 

PS: containers are portable by default so no changes needed there