### PR TITLE
DAGE-74: fixed bug in solr-init.sh

### DIFF
--- a/rre-tools/docker-services/solr-init/solr-init.sh
+++ b/rre-tools/docker-services/solr-init/solr-init.sh
@@ -34,13 +34,13 @@ if [ -f "$EMBEDDINGS_FILE" ] && command -v jq >/dev/null 2>&1; then
   VECTOR_DIM=$(head -n 1 "$EMBEDDINGS_FILE" | jq '.vector | length')
   echo "[INFO] Embeddings file found -> detected embedding dimension: $VECTOR_DIM"
   echo "[INFO] jq available → merging…"
-  jq --slurpfile emb "$EMBEDDINGS_FILE" '       # parse the $EMBEDDINGS_FILE into the var `emb` and execute the following script
+  jq --slurpfile emb "$EMBEDDINGS_FILE" '                      # parse the $EMBEDDINGS_FILE into the var `emb` and execute the following script
   map(
-    . as $doc                                   # save each line of the document in the var `doc`
-    | ($emb[] | select(.id == $doc.id)) as $e   # assign to the var `e` the line of the emb file if it has the same id
+    . as $doc                                                  # save each line of the document in the var `doc`
+    | (first($emb[] | select(.id == $doc.id)) // null) as $e   # assign to the var `e` the line of the emb file if it has the same id
     | if $e != null
-      then $doc + {vector: $e.vector}           # appends the embedding to the document
-      else $doc                                 # otherwise it keeps just the fields
+      then $doc + {vector: $e.vector}                          # appends the embedding to the document
+      else $doc                                                # otherwise it keeps just the fields
       end
   )
 ' "$DATASET_FILE" > "$TMP_FILE"


### PR DESCRIPTION
DAGE-74: [Jira Ticket](https://sease.atlassian.net/browse/DAGE-74)

This is a very fast review. I checked, and it behaves as described below.

The old version was indexing only the documents found in the documents_embeddings.jsonl file. The new version indexes all the documents, even if some embedding is not found. In this case, the collection will have some documents without embeddings, but all the available ones are indexed.


