### PR TITLE
DAGE-91: fixed Solr vector indexing bug

### DIFF
--- a/rre-tools/docker-services/solr-init/solr-init.sh
+++ b/rre-tools/docker-services/solr-init/solr-init.sh
@@ -39,7 +39,9 @@ if [ -f "$EMBEDDINGS_FILE" ] && command -v jq >/dev/null 2>&1; then
     . as $doc                                                  # save each line of the document in the var `doc`
     | (first($emb[] | select(.id == $doc.id)) // null) as $e   # assign to the var `e` the line of the emb file if it has the same id
     | if $e != null
-      then $doc + {vector: $e.vector}                          # appends the embedding to the document
+      then $doc + {
+        vector: ($e.vector | map((. * 1e12 | round) / 1e12))   # appends the embedding to the document rounding each number to 12 decimals
+      }
       else $doc                                                # otherwise it keeps just the fields
       end
   )


### PR DESCRIPTION
DAGE-91: [Jira ticket](https://sease.atlassian.net/browse/DAGE-91)

I spotted a bug in the `solr-init.sh` file: the indexing process is raising a Solr error when the file that contains embeddings has vectors that are too precise (float32 in this case). We need to lower the precision; otherwise, the indexing procedure cannot be successful.