### PR TITLE
DAGE-100: Update OpenAI chat model version

### DIFF
--- a/rre-tools/dataset-generator/llm_config.yaml
+++ b/rre-tools/dataset-generator/llm_config.yaml
@@ -4,10 +4,10 @@
 name: openai
 
 # Chat model name
-model: gpt-4o
+model: gpt-5-nano-2025-08-07
 
 # Maximum number of tokens the model may return
-max_tokens: 512
+max_tokens: 2000
 
 # Environment variable where LLM API key is stored
 api_key_env: OPENAI_API_KEY

--- a/rre-tools/embedding-model-evaluator/src/embedding_model_evaluator/main.py
+++ b/rre-tools/embedding-model-evaluator/src/embedding_model_evaluator/main.py
@@ -84,7 +84,7 @@ def main() -> None:
              config.task_to_evaluate, config.dataset_name, config.split, config.model_id)
 
     # --- Model + caching wrapper ---
-    model = mteb.get_model(config.model_id)
+    model = mteb.get_model(config.model_id, trust_remote_code=True)
     model_name_additional_path = config.model_id.replace("/", "__").replace(" ", "_")
     model_with_cache_path = CACHE_PATH / model_name_additional_path
     model_with_cache = CachedEmbeddingWrapper(model, cache_path=model_with_cache_path)


### PR DESCRIPTION
* updated OpenAI chat model version to the cheapest option, here using the snapshot version, so that performance and behavior remain consistent.
* also added a flag in the mteb embedding model evaluator, while using different models, sometimes a model requires this tag. 