### PR TITLE
DAGE-102: External Solr plugin implementation for version 9.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <jackson.version>2.9.4</jackson.version>
         <elasticsearch.version>7.5.0</elasticsearch.version>
-        <solr.version>8.3.0</solr.version>
+        <solr.version>9.8.1</solr.version>
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/rre-core/pom.xml
+++ b/rre-core/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.10.0</version>
+            <version>2.25.2</version>
         </dependency>
         <dependency>
             <groupId>io.sease</groupId>

--- a/rre-core/src/main/java/io/sease/rre/core/Engine.java
+++ b/rre-core/src/main/java/io/sease/rre/core/Engine.java
@@ -252,16 +252,15 @@ public class Engine {
             // Wait for the evaluations to complete
             while (evaluationManager.isRunning()) {
                 LOGGER.info("  ... completed {} / {} evaluations ...",
-                        (evaluationManager.getTotalQueries() - evaluationManager.getQueriesRemaining()),
-                        evaluationManager.getTotalQueries());
+                        (evaluationManager.getTotalQueryExecutions() - evaluationManager.getQueriesRemaining()),
+                        evaluationManager.getTotalQueryExecutions());
                 try {
                     Thread.sleep(1000);
-                } catch (InterruptedException ignore) {
-                }
+                } catch (InterruptedException ignore) {}
             }
 
-            if (evaluationManager.getTotalQueries() > 0) {
-                LOGGER.info("  ... completed all {} evaluations.", evaluationManager.getTotalQueries());
+            if (evaluationManager.getTotalQueryExecutions() > 0) {
+                LOGGER.info("  ... completed all {} evaluations.", evaluationManager.getTotalQueryExecutions());
             } else {
                 LOGGER.warn("  ... no queries evaluated!");
             }

--- a/rre-core/src/main/java/io/sease/rre/core/domain/DomainMember.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/DomainMember.java
@@ -119,14 +119,20 @@ public abstract class DomainMember<C extends DomainMember> {
      */
     private void collectLeafMetric(final String version, final BigDecimal value, final String name) {
         metric(name).collect(version, value);
-        ofNullable(parent).ifPresent(p -> p.collectLeafMetric(version, value, name));
+
+        if (parent != null) {
+            parent.collectLeafMetric(version, value, name);
+        }
     }
 
-    private void initialiseVersions(final String name, final List<String> versions) {
+    private synchronized void initialiseVersions(final String name, final List<String> versions) {
         if (!metrics.containsKey(name)) {
             metric(name).setVersions(versions);
         }
-        ofNullable(parent).ifPresent(p -> p.initialiseVersions(name, versions));
+
+        if (parent != null) {
+            parent.initialiseVersions(name, versions);
+        }
     }
 
     /**

--- a/rre-core/src/main/java/io/sease/rre/core/domain/DomainMember.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/DomainMember.java
@@ -145,12 +145,15 @@ public abstract class DomainMember<C extends DomainMember> {
                 .forEach(metric -> initialiseVersions(metric.getName(), new ArrayList<>(metric.getVersions().keySet())));
         metrics.values().stream()
                 .flatMap(metric -> metric.getVersions().entrySet().stream())
-                .forEach(entry ->
-                        ofNullable(parent)
-                                .ifPresent(p -> p.collectLeafMetric(
-                                        entry.getKey(),
-                                        entry.getValue().value(),
-                                        entry.getValue().owner().getName())));
+                .forEach(entry -> {
+                    ofNullable(parent).ifPresent(p ->
+                            p.collectLeafMetric(
+                                    entry.getKey(),
+                                    entry.getValue().value(),
+                                    entry.getValue().owner().getName()
+                            )
+                    );
+                });
     }
 
     public Map<String, Metric> getMetrics() {

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/NDCGAtK.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/NDCGAtK.java
@@ -103,7 +103,6 @@ public class NDCGAtK extends Metric {
                         .ifPresent(judgment -> {
                             final BigDecimal value = gainOrRatingNode(judgment).map(JsonNode::decimalValue).orElse(fairgrade);
                             BigDecimal numerator = BigDecimal.valueOf(Math.pow(TWO.doubleValue(), value.doubleValue())).subtract(BigDecimal.ONE);
-                            //BigDecimal numerator = BigDecimal.valueOf(value.doubleValue());
                             if (rank == 1) {
                                 dcg = numerator;
                             } else {
@@ -153,7 +152,6 @@ public class NDCGAtK extends Metric {
         BigDecimal result = BigDecimal.ZERO;
         for (int i = 1; i <= gains.length; i++) {
             BigDecimal num = BigDecimal.valueOf(Math.pow(TWO.doubleValue(), gains[i-1])).subtract(BigDecimal.ONE);
-            //BigDecimal num = BigDecimal.valueOf(gains[i-1]);
             double den = Math.log(i + 1) / Math.log(2);
             result = result.add((num.divide(new BigDecimal(den), 2, RoundingMode.FLOOR)));
         }

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/NDCGAtK.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/NDCGAtK.java
@@ -103,6 +103,7 @@ public class NDCGAtK extends Metric {
                         .ifPresent(judgment -> {
                             final BigDecimal value = gainOrRatingNode(judgment).map(JsonNode::decimalValue).orElse(fairgrade);
                             BigDecimal numerator = BigDecimal.valueOf(Math.pow(TWO.doubleValue(), value.doubleValue())).subtract(BigDecimal.ONE);
+                            //BigDecimal numerator = BigDecimal.valueOf(value.doubleValue());
                             if (rank == 1) {
                                 dcg = numerator;
                             } else {
@@ -152,6 +153,7 @@ public class NDCGAtK extends Metric {
         BigDecimal result = BigDecimal.ZERO;
         for (int i = 1; i <= gains.length; i++) {
             BigDecimal num = BigDecimal.valueOf(Math.pow(TWO.doubleValue(), gains[i-1])).subtract(BigDecimal.ONE);
+            //BigDecimal num = BigDecimal.valueOf(gains[i-1]);
             double den = Math.log(i + 1) / Math.log(2);
             result = result.add((num.divide(new BigDecimal(den), 2, RoundingMode.FLOOR)));
         }

--- a/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/AsynchronousEvaluationManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/AsynchronousEvaluationManager.java
@@ -40,14 +40,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author Matt Pearce (matt@flax.co.uk)
  */
-public class AsynchronousEvaluationManager extends BaseEvaluationManager implements EvaluationManager {
+public class AsynchronousEvaluationManager extends BaseEvaluationManager {
 
     private final static Logger LOGGER = LogManager.getLogger(AsynchronousEvaluationManager.class);
 
     private final ThreadPoolExecutor executor;
     private AtomicInteger failedQueries;
-
-    private CompletableFuture<Void> allQueriesFuture = CompletableFuture.completedFuture(null);
 
     /**
      * Construct an asynchronous {@link EvaluationManager} instance to run
@@ -75,10 +73,13 @@ public class AsynchronousEvaluationManager extends BaseEvaluationManager impleme
 
     @Override
     public void evaluateQuery(Query query, String indexName, JsonNode queryNode, String defaultTemplate, int relevantDocCount) {
-        allQueriesFuture = allQueriesFuture.thenCompose(v ->
-                this.evaluateQueryAsync(query, indexName, queryNode, defaultTemplate, relevantDocCount)
-                        .thenAccept(this::completeQuery)
-        );
+        super.evaluateQuery(query, indexName, queryNode, defaultTemplate, relevantDocCount);
+        this.evaluateQueryAsync(query, indexName, queryNode, defaultTemplate, relevantDocCount)
+                .thenAccept(this::completeQuery)
+                .exceptionally(error -> {
+                    LOGGER.error("Query FAILED: " + error.getMessage(), error);
+                    return null;
+                });
     }
 
     /**
@@ -120,7 +121,7 @@ public class AsynchronousEvaluationManager extends BaseEvaluationManager impleme
 
     @Override
     public boolean isRunning() {
-        return executor.getCompletedTaskCount() < executor.getTaskCount() && !allQueriesFuture.isDone();
+        return super.getCompletedQueries() < super.getSubmittedQueries();
     }
 
     @Override

--- a/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/AsynchronousEvaluationManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/AsynchronousEvaluationManager.java
@@ -47,6 +47,8 @@ public class AsynchronousEvaluationManager extends BaseEvaluationManager impleme
     private final ThreadPoolExecutor executor;
     private AtomicInteger failedQueries;
 
+    private CompletableFuture<Void> allQueriesFuture = CompletableFuture.completedFuture(null);
+
     /**
      * Construct an asynchronous {@link EvaluationManager} instance to run
      * evaluations using a threadpool of a given size.
@@ -73,8 +75,10 @@ public class AsynchronousEvaluationManager extends BaseEvaluationManager impleme
 
     @Override
     public void evaluateQuery(Query query, String indexName, JsonNode queryNode, String defaultTemplate, int relevantDocCount) {
-        evaluateQueryAsync(query, indexName, queryNode, defaultTemplate, relevantDocCount)
-                .thenAccept(this::completeQuery);
+        allQueriesFuture = allQueriesFuture.thenCompose(v ->
+                this.evaluateQueryAsync(query, indexName, queryNode, defaultTemplate, relevantDocCount)
+                        .thenAccept(this::completeQuery)
+        );
     }
 
     /**
@@ -116,7 +120,7 @@ public class AsynchronousEvaluationManager extends BaseEvaluationManager impleme
 
     @Override
     public boolean isRunning() {
-        return executor.getCompletedTaskCount() < executor.getTaskCount();
+        return executor.getCompletedTaskCount() < executor.getTaskCount() && !allQueriesFuture.isDone();
     }
 
     @Override

--- a/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/AsynchronousQueryEvaluationManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/AsynchronousQueryEvaluationManager.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author Matt Pearce (matt@flax.co.uk)
  */
-public class AsynchronousQueryEvaluationManager extends BaseEvaluationManager implements EvaluationManager {
+public class AsynchronousQueryEvaluationManager extends BaseEvaluationManager {
 
     private final static Logger LOGGER = LogManager.getLogger(AsynchronousQueryEvaluationManager.class);
 
@@ -72,6 +72,7 @@ public class AsynchronousQueryEvaluationManager extends BaseEvaluationManager im
 
     @Override
     public void evaluateQuery(Query query, String indexName, JsonNode queryNode, String defaultTemplate, int relevantDocCount) {
+        super.evaluateQuery(query, indexName, queryNode, defaultTemplate, relevantDocCount);
         evaluateQueryAsync(query, indexName, queryNode, defaultTemplate, relevantDocCount)
                 .thenAccept(this::completeQuery);
     }
@@ -115,7 +116,7 @@ public class AsynchronousQueryEvaluationManager extends BaseEvaluationManager im
 
     @Override
     public boolean isRunning() {
-        return executor.getCompletedTaskCount() < executor.getTaskCount();
+        return super.getSubmittedQueries() < super.getCompletedQueries();
     }
 
     @Override

--- a/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/AsynchronousQueryEvaluationManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/AsynchronousQueryEvaluationManager.java
@@ -116,7 +116,7 @@ public class AsynchronousQueryEvaluationManager extends BaseEvaluationManager {
 
     @Override
     public boolean isRunning() {
-        return super.getSubmittedQueries() < super.getCompletedQueries();
+        return executor.getCompletedTaskCount() < executor.getTaskCount();
     }
 
     @Override

--- a/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/BaseEvaluationManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/BaseEvaluationManager.java
@@ -17,8 +17,8 @@
 package io.sease.rre.core.evaluation.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.sease.rre.core.Engine;
 import io.sease.rre.core.domain.Query;
+import io.sease.rre.core.evaluation.EvaluationManager;
 import io.sease.rre.core.template.QueryTemplateManager;
 import io.sease.rre.persistence.PersistenceManager;
 import io.sease.rre.search.api.QueryOrSearchResponse;
@@ -27,6 +27,7 @@ import io.sease.rre.search.api.SearchPlatform;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Optional.ofNullable;
 
@@ -36,7 +37,7 @@ import static java.util.Optional.ofNullable;
  *
  * @author Matt Pearce (matt@flax.co.uk)
  */
-abstract class BaseEvaluationManager {
+abstract class BaseEvaluationManager implements EvaluationManager {
 
     private final SearchPlatform platform;
     private final QueryTemplateManager templateManager;
@@ -44,6 +45,8 @@ abstract class BaseEvaluationManager {
     private final String[] fields;
     private final Collection<String> versions;
     private final String versionTimestamp;
+    private final AtomicInteger submittedQueries = new AtomicInteger(0);
+    private final AtomicInteger completedQueries = new AtomicInteger(0);
 
     BaseEvaluationManager(SearchPlatform platform,
                           QueryTemplateManager templateManager,
@@ -81,6 +84,7 @@ abstract class BaseEvaluationManager {
     void completeQuery(Query query) {
         query.notifyCollectedMetrics();
         persistenceManager.recordQuery(query);
+        completedQueries.incrementAndGet();
     }
 
     /**
@@ -127,5 +131,17 @@ abstract class BaseEvaluationManager {
      */
     String persistVersion(final String configVersion) {
         return ofNullable(versionTimestamp).orElse(configVersion);
+    }
+
+    public void evaluateQuery(Query query, String indexName, JsonNode queryNode, String defaultTemplate, int relevantDocCount) {
+        this.submittedQueries.incrementAndGet();
+    }
+
+    public int getSubmittedQueries() {
+        return this.submittedQueries.get();
+    }
+
+    public int getCompletedQueries() {
+        return this.completedQueries.get();
     }
 }

--- a/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/SynchronousEvaluationManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/evaluation/impl/SynchronousEvaluationManager.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author Matt Pearce (matt@flax.co.uk)
  */
-public class SynchronousEvaluationManager extends BaseEvaluationManager implements EvaluationManager {
+public class SynchronousEvaluationManager extends BaseEvaluationManager {
 
     private int queryCount;
     private int failedQueries;

--- a/rre-core/src/main/java/io/sease/rre/persistence/impl/JsonPersistenceHandler.java
+++ b/rre-core/src/main/java/io/sease/rre/persistence/impl/JsonPersistenceHandler.java
@@ -120,7 +120,7 @@ public class JsonPersistenceHandler implements PersistenceHandler {
             ObjectWriter writer = (pretty ? mapper.writerWithDefaultPrettyPrinter() : mapper.writer());
             writer.writeValue(new File(outputFilepath), topLevel);
         } catch (IOException e) {
-            LOGGER.error("Caught IOException writing queries to JSON :: " + e.getMessage());
+            LOGGER.error("Caught IOException writing queries to JSON :: " + e.getMessage(), e);
         }
     }
 

--- a/rre-maven-plugin/pom.xml
+++ b/rre-maven-plugin/pom.xml
@@ -139,7 +139,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.6.1</version>
                 <configuration>
                     <goalPrefix>rre</goalPrefix>
                 </configuration>

--- a/rre-maven-plugin/rre-maven-external-solr-plugin/pom.xml
+++ b/rre-maven-plugin/rre-maven-external-solr-plugin/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>rre-maven-external-solr-plugin</artifactId>
-    <version>8.3.0</version>
+    <version>9.8.1</version>
     <packaging>maven-plugin</packaging>
     <name>RRE - Maven External Apache Solr Plugin</name>
     <dependencies>

--- a/rre-maven-plugin/rre-maven-solr-plugin/pom.xml
+++ b/rre-maven-plugin/rre-maven-solr-plugin/pom.xml
@@ -27,7 +27,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rre-maven-solr-plugin</artifactId>
-    <version>8.3.0</version>
+    <version>9.8.1</version>
     <packaging>maven-plugin</packaging>
     <name>RRE - Maven Apache Solr Plugin</name>
     <dependencies>

--- a/rre-search-platform/rre-search-platform-external-solr-impl/pom.xml
+++ b/rre-search-platform/rre-search-platform-external-solr-impl/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>rre-search-platform-external-solr-impl</artifactId>
     <name>RRE - External Solr search platform binding</name>
 
-    <version>8.3.0</version>
+    <version>9.8.1</version>
 
     <build>
         <plugins>
@@ -101,6 +101,11 @@
             <artifactId>solr</artifactId>
             <version>1.15.0-rc2</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.16.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/rre-search-platform/rre-search-platform-external-solr-impl/pom.xml
+++ b/rre-search-platform/rre-search-platform-external-solr-impl/pom.xml
@@ -85,16 +85,6 @@
             <artifactId>solr-test-framework</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.restlet.jee</groupId>
-                    <artifactId>org.restlet</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.restlet.jee</groupId>
-                    <artifactId>org.restlet.ext.servlet</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/rre-search-platform/rre-search-platform-external-solr-impl/src/main/java/io/sease/rre/search/api/impl/SolrClientManager.java
+++ b/rre-search-platform/rre-search-platform-external-solr-impl/src/main/java/io/sease/rre/search/api/impl/SolrClientManager.java
@@ -66,15 +66,21 @@ class SolrClientManager implements Closeable {
     }
 
     /**
-     * Apply the timeout settings using methods common to all SolrClientBuilder
-     * implementations.
+     * Apply the timeout settings for cloud implementations involving
+     * CloudHttp2SolrClient.Builder. Uses internally the non-cloud function to
+     * maintain the same timeout configuration.
      *
-     * @param builder  the SolrClientBuilder.
+     * @param builder  the CloudHttp2SolrClient.Builder.
      * @param settings the SolrSettings, containing the (optional) timeout settings.
-     * @param <C>      the type of SolrClientBuilder in use.
-     * @return the SolrClientBuilder with the timeout settings applied.
+     * @return the CloudHttp2SolrClient.Builder with the timeout settings applied.
      */
     private CloudHttp2SolrClient.Builder applyTimeoutSettings(CloudHttp2SolrClient.Builder builder, ExternalApacheSolr.SolrSettings settings) {
+
+        Http2SolrClient.Builder httpBuilder = new Http2SolrClient.Builder();
+        applyTimeoutSettings(httpBuilder, settings);
+
+        builder.withInternalClientBuilder(httpBuilder);
+
         if (settings.getConnectionTimeout() != null) {
             builder.withZkConnectTimeout(settings.getConnectionTimeout(), TimeUnit.MILLISECONDS);
         }
@@ -83,13 +89,21 @@ class SolrClientManager implements Closeable {
         }
         return builder;
     }
-
+    /**
+     * Apply the timeout settings for non-cloud implementations involving
+     * Http2SolrClient.Builder.
+     *
+     * @param builder  the Http2SolrClient.Builder.
+     * @param settings the SolrSettings, containing the (optional) timeout settings.
+     * @return the Http2SolrClient.Builder with the timeout settings applied.
+     */
     private Http2SolrClient.Builder applyTimeoutSettings(Http2SolrClient.Builder builder, ExternalApacheSolr.SolrSettings settings) {
+        builder.withIdleTimeout(30, TimeUnit.SECONDS);
         if (settings.getConnectionTimeout() != null) {
             builder.withConnectionTimeout(settings.getConnectionTimeout(), TimeUnit.MILLISECONDS);
         }
         if (settings.getSocketTimeout() != null) {
-            builder.withIdleTimeout(settings.getSocketTimeout(), TimeUnit.MILLISECONDS);
+            builder.withRequestTimeout(settings.getSocketTimeout(), TimeUnit.MILLISECONDS);
         }
         return builder;
     }

--- a/rre-search-platform/rre-search-platform-external-solr-impl/src/main/java/io/sease/rre/search/api/impl/SolrClientManager.java
+++ b/rre-search-platform/rre-search-platform-external-solr-impl/src/main/java/io/sease/rre/search/api/impl/SolrClientManager.java
@@ -18,8 +18,7 @@ package io.sease.rre.search.api.impl;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
-import org.apache.solr.client.solrj.impl.HttpSolrClient;
-import org.apache.solr.client.solrj.impl.SolrClientBuilder;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +26,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Manager class for Solr Clients in use when connecting to external Solr instances.
@@ -58,7 +58,7 @@ class SolrClientManager implements Closeable {
             final CloudSolrClient.Builder builder = new CloudSolrClient.Builder(settings.getBaseUrls());
             client = applyTimeoutSettings(builder, settings).build();
         } else {
-            final HttpSolrClient.Builder builder = new HttpSolrClient.Builder(settings.getBaseUrls().get(0));
+            final Http2SolrClient.Builder builder = new Http2SolrClient.Builder(settings.getBaseUrls().get(0));
             client = applyTimeoutSettings(builder, settings).build();
         }
 
@@ -74,12 +74,22 @@ class SolrClientManager implements Closeable {
      * @param <C>      the type of SolrClientBuilder in use.
      * @return the SolrClientBuilder with the timeout settings applied.
      */
-    private <C extends SolrClientBuilder> C applyTimeoutSettings(C builder, ExternalApacheSolr.SolrSettings settings) {
+    private CloudSolrClient.Builder applyTimeoutSettings(CloudSolrClient.Builder builder, ExternalApacheSolr.SolrSettings settings) {
         if (settings.getConnectionTimeout() != null) {
-            builder.withConnectionTimeout(settings.getConnectionTimeout());
+            builder.withZkConnectTimeout(settings.getConnectionTimeout(), TimeUnit.MILLISECONDS);
         }
         if (settings.getSocketTimeout() != null) {
-            builder.withSocketTimeout(settings.getSocketTimeout());
+            builder.withZkClientTimeout(settings.getSocketTimeout(), TimeUnit.MILLISECONDS);
+        }
+        return builder;
+    }
+
+    private Http2SolrClient.Builder applyTimeoutSettings(Http2SolrClient.Builder builder, ExternalApacheSolr.SolrSettings settings) {
+        if (settings.getConnectionTimeout() != null) {
+            builder.withRequestTimeout(settings.getConnectionTimeout(), TimeUnit.MILLISECONDS);
+        }
+        if (settings.getSocketTimeout() != null) {
+            builder.withIdleTimeout(settings.getSocketTimeout(), TimeUnit.MILLISECONDS);
         }
         return builder;
     }

--- a/rre-search-platform/rre-search-platform-external-solr-impl/src/main/java/io/sease/rre/search/api/impl/SolrClientManager.java
+++ b/rre-search-platform/rre-search-platform-external-solr-impl/src/main/java/io/sease/rre/search/api/impl/SolrClientManager.java
@@ -17,7 +17,7 @@
 package io.sease.rre.search.api.impl;
 
 import org.apache.solr.client.solrj.SolrClient;
-import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.CloudHttp2SolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,10 +52,10 @@ class SolrClientManager implements Closeable {
         final SolrClient client;
 
         if (settings.hasZookeeperSettings()) {
-            final CloudSolrClient.Builder builder = new CloudSolrClient.Builder(settings.getZkHosts(), settings.getZkChroot());
+            final CloudHttp2SolrClient.Builder builder = new CloudHttp2SolrClient.Builder(settings.getZkHosts(), settings.getZkChroot());
             client = applyTimeoutSettings(builder, settings).build();
         } else if (settings.getBaseUrls().size() > 1) {
-            final CloudSolrClient.Builder builder = new CloudSolrClient.Builder(settings.getBaseUrls());
+            final CloudHttp2SolrClient.Builder builder = new CloudHttp2SolrClient.Builder(settings.getBaseUrls());
             client = applyTimeoutSettings(builder, settings).build();
         } else {
             final Http2SolrClient.Builder builder = new Http2SolrClient.Builder(settings.getBaseUrls().get(0));
@@ -74,7 +74,7 @@ class SolrClientManager implements Closeable {
      * @param <C>      the type of SolrClientBuilder in use.
      * @return the SolrClientBuilder with the timeout settings applied.
      */
-    private CloudSolrClient.Builder applyTimeoutSettings(CloudSolrClient.Builder builder, ExternalApacheSolr.SolrSettings settings) {
+    private CloudHttp2SolrClient.Builder applyTimeoutSettings(CloudHttp2SolrClient.Builder builder, ExternalApacheSolr.SolrSettings settings) {
         if (settings.getConnectionTimeout() != null) {
             builder.withZkConnectTimeout(settings.getConnectionTimeout(), TimeUnit.MILLISECONDS);
         }
@@ -86,7 +86,7 @@ class SolrClientManager implements Closeable {
 
     private Http2SolrClient.Builder applyTimeoutSettings(Http2SolrClient.Builder builder, ExternalApacheSolr.SolrSettings settings) {
         if (settings.getConnectionTimeout() != null) {
-            builder.withRequestTimeout(settings.getConnectionTimeout(), TimeUnit.MILLISECONDS);
+            builder.withConnectionTimeout(settings.getConnectionTimeout(), TimeUnit.MILLISECONDS);
         }
         if (settings.getSocketTimeout() != null) {
             builder.withIdleTimeout(settings.getSocketTimeout(), TimeUnit.MILLISECONDS);

--- a/rre-search-platform/rre-search-platform-external-solr-impl/src/test/java/io/sease/rre/search/api/impl/SolrClientManagerTest.java
+++ b/rre-search-platform/rre-search-platform-external-solr-impl/src/test/java/io/sease/rre/search/api/impl/SolrClientManagerTest.java
@@ -16,10 +16,12 @@
  */
 package io.sease.rre.search.api.impl;
 
-import org.apache.solr.client.solrj.embedded.JettyConfig;
+import org.apache.solr.embedded.JettyConfig;
+import org.apache.solr.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
-import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.cloud.MiniSolrCloudCluster;
+import org.apache.solr.core.SolrCore;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,14 +61,14 @@ public class SolrClientManagerTest {
     }
 
     @Test
-    public void buildsHttpSolrClientForSingleHost() {
+    public void buildsHttp2SolrClientForSingleHost() {
         ExternalApacheSolr.SolrSettings settings = new ExternalApacheSolr.SolrSettings(
                 Collections.singletonList("http://localhost:8983/solr"), null, null, null, null, null);
 
         clientManager.buildSolrClient(TARGET_INDEX, settings);
 
         assertNotNull(clientManager.getSolrClient(TARGET_INDEX));
-        assertTrue(clientManager.getSolrClient(TARGET_INDEX) instanceof HttpSolrClient);
+        assertTrue(clientManager.getSolrClient(TARGET_INDEX) instanceof Http2SolrClient);
     }
 
     @Test

--- a/rre-search-platform/rre-search-platform-external-solr-impl/src/test/java/io/sease/rre/search/api/impl/SolrClientManagerTest.java
+++ b/rre-search-platform/rre-search-platform-external-solr-impl/src/test/java/io/sease/rre/search/api/impl/SolrClientManagerTest.java
@@ -17,11 +17,9 @@
 package io.sease.rre.search.api.impl;
 
 import org.apache.solr.embedded.JettyConfig;
-import org.apache.solr.embedded.JettySolrRunner;
-import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.CloudHttp2SolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.cloud.MiniSolrCloudCluster;
-import org.apache.solr.core.SolrCore;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -72,11 +70,11 @@ public class SolrClientManagerTest {
     }
 
     @Test
-    public void buildsCloudSolrClientForMultipleHosts() throws Exception {
+    public void buildsCloudHttp2SolrClientForMultipleHosts() throws Exception {
         // Set a dummy log directory, to stop Solr complaining at start-up
         System.setProperty("solr.log.dir", tempFolder.newFolder("logs").getAbsolutePath());
 
-        // Build a mini cluster to test with - cannot initialise CloudSolrClient without something to connect to
+        // Build a mini cluster to test with - cannot initialise CloudHttp2SolrClient without something to connect to
         MiniSolrCloudCluster cluster =
                 new MiniSolrCloudCluster(2, tempFolder.newFolder().toPath(), JettyConfig.builder().build());
         cluster.startJettySolrRunner();
@@ -90,19 +88,19 @@ public class SolrClientManagerTest {
         clientManager.buildSolrClient(TARGET_INDEX, settings);
 
         assertNotNull(clientManager.getSolrClient(TARGET_INDEX));
-        assertTrue(clientManager.getSolrClient(TARGET_INDEX) instanceof CloudSolrClient);
+        assertTrue(clientManager.getSolrClient(TARGET_INDEX) instanceof CloudHttp2SolrClient);
 
         cluster.shutdown();
     }
 
     @Test
-    public void buildsCloudSolrClientForZkHosts() {
+    public void buildsCloudHttp2SolrClientForZkHosts() {
         ExternalApacheSolr.SolrSettings settings = new ExternalApacheSolr.SolrSettings(
                 null, null, asList("localhost:2181", "localhost:2182"), null, null, null);
 
         clientManager.buildSolrClient(TARGET_INDEX, settings);
 
         assertNotNull(clientManager.getSolrClient(TARGET_INDEX));
-        assertTrue(clientManager.getSolrClient(TARGET_INDEX) instanceof CloudSolrClient);
+        assertTrue(clientManager.getSolrClient(TARGET_INDEX) instanceof CloudHttp2SolrClient);
     }
 }

--- a/rre-search-platform/rre-search-platform-solr-impl/pom.xml
+++ b/rre-search-platform/rre-search-platform-solr-impl/pom.xml
@@ -27,9 +27,14 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rre-search-platform-solr-impl</artifactId>
-    <version>8.3.0</version>
+    <version>9.8.1</version>
     <name>RRE - Apache Solr platform binding</name>
     <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.25.2</version>
+        </dependency>
         <dependency>
             <groupId>io.sease</groupId>
             <artifactId>rre-search-platform-api</artifactId>


### PR DESCRIPTION
DAGE-102: [Jira ticket](https://sease.atlassian.net/browse/DAGE-102)

Update External Solr plugin to version 9.8.1 -> no more dependencies on restlet -> no more compilation problems since restlet version needed by solr 8.3.0 was deprecated.

Fixed bug in logging the number of queries that needs to be executed: before, with more than one version, it happened something like "...completed -10 / 10 ..." queries, now is fixed.

After SolrJ 9.3.x, the class HttpSolrClient has been depracated, so the need to change into Http2SolrClient. The change has been made also for CloudHttp2SolrClient one, to be aligned with the rest of the code. 

A lot of bug raised, due to aynchronism and parallelism of task. Things done to solve:
1. added to counters `submittedQueries` and `completedQueries`.
2. added synchronized to the function `initialiseVersions`, to solve Concurrency exceptions.
3. `isRunning` function changed accordingly to use new counters from point 1, to check the actual retrieval of all the data needed to proceed with the computation of the resulting json file (serialization).