### PR TITLE
DAGE-110: nDCG formula update in RRE code

### DIFF
--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/MetricClassConfigurationManager.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/MetricClassConfigurationManager.java
@@ -15,7 +15,7 @@ public class MetricClassConfigurationManager {
     private static MetricClassConfigurationManager INSTANCE = new MetricClassConfigurationManager();
 
     private BigDecimal defaultMaximumGrade = BigDecimal.valueOf(3);
-    private BigDecimal defaultMissingGrade = BigDecimal.valueOf(2);
+    private BigDecimal defaultMissingGrade = BigDecimal.valueOf(0);
 
     public static MetricClassConfigurationManager getInstance() {
         return INSTANCE;

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/NDCGAtK.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/NDCGAtK.java
@@ -108,7 +108,7 @@ public class NDCGAtK extends Metric {
                                 dcg = numerator;
                             } else {
                                 double den = Math.log(rank + 1) / Math.log(2);
-                                dcg = dcg.add(numerator.divide(new BigDecimal(den), 2, RoundingMode.FLOOR));
+                                dcg = dcg.add(numerator.divide(new BigDecimal(den), 5, RoundingMode.FLOOR));
                             }
                         });
             }
@@ -155,7 +155,7 @@ public class NDCGAtK extends Metric {
             //BigDecimal num = BigDecimal.valueOf(Math.pow(TWO.doubleValue(), gains[i-1])).subtract(BigDecimal.ONE);
             BigDecimal num = BigDecimal.valueOf(gains[i-1]);
             double den = Math.log(i + 1) / Math.log(2);
-            result = result.add((num.divide(new BigDecimal(den), 2, RoundingMode.FLOOR)));
+            result = result.add((num.divide(new BigDecimal(den), 5, RoundingMode.FLOOR)));
         }
 
         return result;

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/NDCGAtK.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/NDCGAtK.java
@@ -102,7 +102,8 @@ public class NDCGAtK extends Metric {
                 judgment(id(hit))
                         .ifPresent(judgment -> {
                             final BigDecimal value = gainOrRatingNode(judgment).map(JsonNode::decimalValue).orElse(fairgrade);
-                            BigDecimal numerator = BigDecimal.valueOf(Math.pow(TWO.doubleValue(), value.doubleValue())).subtract(BigDecimal.ONE);
+                            //BigDecimal numerator = BigDecimal.valueOf(Math.pow(TWO.doubleValue(), value.doubleValue())).subtract(BigDecimal.ONE);
+                            BigDecimal numerator = BigDecimal.valueOf(value.doubleValue());
                             if (rank == 1) {
                                 dcg = numerator;
                             } else {
@@ -151,7 +152,8 @@ public class NDCGAtK extends Metric {
         
         BigDecimal result = BigDecimal.ZERO;
         for (int i = 1; i <= gains.length; i++) {
-            BigDecimal num = BigDecimal.valueOf(Math.pow(TWO.doubleValue(), gains[i-1])).subtract(BigDecimal.ONE);
+            //BigDecimal num = BigDecimal.valueOf(Math.pow(TWO.doubleValue(), gains[i-1])).subtract(BigDecimal.ONE);
+            BigDecimal num = BigDecimal.valueOf(gains[i-1]);
             double den = Math.log(i + 1) / Math.log(2);
             result = result.add((num.divide(new BigDecimal(den), 2, RoundingMode.FLOOR)));
         }

--- a/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/NDCGAtK.java
+++ b/rre-core/src/main/java/io/sease/rre/core/domain/metrics/impl/NDCGAtK.java
@@ -102,7 +102,6 @@ public class NDCGAtK extends Metric {
                 judgment(id(hit))
                         .ifPresent(judgment -> {
                             final BigDecimal value = gainOrRatingNode(judgment).map(JsonNode::decimalValue).orElse(fairgrade);
-                            //BigDecimal numerator = BigDecimal.valueOf(Math.pow(TWO.doubleValue(), value.doubleValue())).subtract(BigDecimal.ONE);
                             BigDecimal numerator = BigDecimal.valueOf(value.doubleValue());
                             if (rank == 1) {
                                 dcg = numerator;
@@ -152,7 +151,6 @@ public class NDCGAtK extends Metric {
         
         BigDecimal result = BigDecimal.ZERO;
         for (int i = 1; i <= gains.length; i++) {
-            //BigDecimal num = BigDecimal.valueOf(Math.pow(TWO.doubleValue(), gains[i-1])).subtract(BigDecimal.ONE);
             BigDecimal num = BigDecimal.valueOf(gains[i-1]);
             double den = Math.log(i + 1) / Math.log(2);
             result = result.add((num.divide(new BigDecimal(den), 5, RoundingMode.FLOOR)));

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/NDCGAtKTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/NDCGAtKTestCase.java
@@ -199,16 +199,16 @@ public class NDCGAtKTestCase extends BaseTestCase {
 
         Map<Integer, Double> expectations = new HashMap<Integer, Double>()
         {{
-            put(1,0.06);
-            put(2,0.14);
-            put(3,0.3);
-            put(4,0.57);
-            put(5,0.62);
-            put(6,0.62);
-            put(7,0.62);
-            put(8, 0.62);
-            put(9,0.62);
-            put(10, 0.62);
+            put(1,0.25);
+            put(2,0.38);
+            put(3,0.54);
+            put(4,0.7);
+            put(5,0.76);
+            put(6,0.76);
+            put(7,0.76);
+            put(8, 0.76);
+            put(9,0.76);
+            put(10, 0.76);
         }};
 
         assertEquals(

--- a/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/NDCGAtTenTestCase.java
+++ b/rre-core/src/test/java/io.sease.rre.core.domain.metrics.impl/NDCGAtTenTestCase.java
@@ -97,10 +97,10 @@ public class NDCGAtTenTestCase extends BaseTestCase {
     }
 
     /**
-     * Scenario: 10 judgments, 15 search results, 5 relevant results in top positions.
+     * Scenario: 10 judgments, 15 search results, 5 relevant results from 6th to 10th position.
      */
     @Test
-    public void _10_judgments_15_search_results_5_relevant_results_from_5th_to_10th() {
+    public void _10_judgments_15_search_results_5_relevant_results_from_6th_to_10th() {
         final ObjectNode judgements = mapper.createObjectNode();
         stream(FIFTEEN_SEARCH_HITS).skip(5).forEach(docid -> judgements.set(docid, createJudgmentNode(3)));
         cut.setRelevantDocuments(judgements);
@@ -136,7 +136,7 @@ public class NDCGAtTenTestCase extends BaseTestCase {
                 .forEach(hit -> cut.collect(hit, counter.incrementAndGet(), A_VERSION));
 
         assertEquals(
-                0.62,
+                0.76,
                 cut.valueFactory(A_VERSION).value().doubleValue(),
                 0);
     }

--- a/rre-tools/configs/dataset_generator/dataset_generator_config.yaml
+++ b/rre-tools/configs/dataset_generator/dataset_generator_config.yaml
@@ -27,7 +27,7 @@ search_engine_url: "http://localhost:8983/solr/"
 #      - "book"
 
 # Maximum number of documents to retrieve from the search engine to generate queries
-number_of_docs: 2
+number_of_docs: 20
 
 # List of fields from documents used to generate queries and relevance scoring
 # These should match fields available in the search engine schema
@@ -39,14 +39,14 @@ doc_fields:
 
 # (Optional) File containing predefined queries to use instead of or alongside generated ones
 # If available, must be in a txt format.
-#queries: "templates/queries.txt"
+queries: "templates/queries.txt"
 
 # (Optional) Whether to generate queries from documents
 # Default: true; set to false to disable query generation from documents
 generate_queries_from_documents: true
 
 # Total number of queries to generate (includes predefined queries, if any)
-num_queries_needed: 4
+num_queries_needed: 30
 
 # Relevance scale used for scoring document relevance
 # Accepted values:
@@ -88,7 +88,7 @@ output_destination: "resources"
 
 # (Optional) Periodically persist in-memory datastore every N successful updates
 # Lower values persist more frequently (safer) but can be slower; higher values persist less often (faster)
-#datastore_autosave_every_n_updates: 50
+datastore_autosave_every_n_updates: 50
 
 # (Optional) Whether to enable scoring the cartesian product between the queries generated and the documents used to
 # generate the queries.


### PR DESCRIPTION
DAGE-110: [Jira ticket](https://sease.atlassian.net/browse/DAGE-110)

This PR is on top of [DAGE-102](https://github.com/SeaseLtd/rated-ranking-evaluator/pull/252). Better to merge the other one first. 

Related to this PR: 
- changes to NDCGAtK: implemented same metric to MTEB, with the first formula [here](https://en.wikipedia.org/wiki/Discounted_cumulative_gain).
- changes to tests related to NDCGAtK and NDCGAtTen, Fixed where needed the expected value of the metric