### PR TITLE
DAGE-119: added enable_cartesian_product parameter for dataset_generator config class

### DIFF
--- a/rre-tools/configs/dataset_generator/dataset_generator_config.yaml
+++ b/rre-tools/configs/dataset_generator/dataset_generator_config.yaml
@@ -89,3 +89,8 @@ output_destination: "resources"
 # (Optional) Periodically persist in-memory datastore every N successful updates
 # Lower values persist more frequently (safer) but can be slower; higher values persist less often (faster)
 #datastore_autosave_every_n_updates: 50
+
+# (Optional) Whether to enable scoring the cartesian product between the queries generated and the documents used to
+# generate the queries.
+# Default: true; the pairs mentioned above are scored.
+enable_cartesian_product: false

--- a/rre-tools/docs/dataset_generator/README.md
+++ b/rre-tools/docs/dataset_generator/README.md
@@ -53,7 +53,9 @@ one fields, the documents are filtered for both fields (AND-like)
 > - **llm_explanation_destination** (Needed only if `save_llm_explanation: true`): File path where it contains 
 > <query, doc_id, rating, explanation> records (e.g., "resources/rating_explanation.json")
 > - **datastore_autosave_every_n_updates** (Optional): Number of successful updates (adds or ratings) after which 
-> - the in-memory datastore is saved. If not given, the datastore is saved at the end of the process.
+> the in-memory datastore is saved. If not given, the datastore is saved at the end of the process.
+> - **enable_cartesian_product** (Optional): Enable cartesian product scoring between queries and documents used to 
+> generate queries. Defaults to `true`
 
 #### Some important things to add
 

--- a/rre-tools/src/rre_tools/dataset_generator/config.py
+++ b/rre-tools/src/rre_tools/dataset_generator/config.py
@@ -43,6 +43,10 @@ class Config(BaseModel):
     datastore_autosave_every_n_updates: Optional[int] = Field(None, gt=0,
         description="If set, periodically persist datastore every N successful updates (adds/ratings)."
     )
+    enable_cartesian_product: bool = Field(
+        True,
+        description="Enable cartesian product scoring between queries and documents used to generate queries."
+    )
 
     def build_writer_config(self) -> WriterConfig:
         if self.rre_query_template is not None:

--- a/rre-tools/src/rre_tools/dataset_generator/main.py
+++ b/rre-tools/src/rre_tools/dataset_generator/main.py
@@ -148,7 +148,8 @@ def main() -> None:
     generate_and_add_queries(config, data_store, service, search_engine)
 
     # score initial docset
-    add_cartesian_product_scores(config, data_store, service)
+    if config.enable_cartesian_product:
+        add_cartesian_product_scores(config, data_store, service)
 
     # expand the docset with search engine topK (adding direct ratings)
     expand_docset_with_search_engine_top_k(config, data_store, service, search_engine)

--- a/rre-tools/tests/dataset_generator/test_config_dataset_generator.py
+++ b/rre-tools/tests/dataset_generator/test_config_dataset_generator.py
@@ -32,21 +32,25 @@ def test_good_config__expects__all_parameters_read(config):
     assert config.output_destination == Path("output")
     assert config.save_llm_explanation is True
     assert config.llm_explanation_destination == Path("output/rating_explanation.json")
-
-    # New optional param: defaults to None when not provided
-    assert hasattr(config, "datastore_autosave_every_n_updates")
-    assert config.datastore_autosave_every_n_updates is None
+    assert config.datastore_autosave_every_n_updates == 50
+    assert not config.enable_cartesian_product
 
 
 def test_missing_optional_field_values__expects__all_defaults_read(resource_folder):
     file_name = "missing_optional.yaml"
-    cfg = Config.load(resource_folder / file_name)
+    config = Config.load(resource_folder / file_name)
 
-    assert hasattr(cfg, "queries")
-    assert cfg.queries is None
+    assert hasattr(config, "queries")
+    assert config.queries is None
 
-    assert hasattr(cfg, "query_template")
-    assert cfg.query_template is None
+    assert hasattr(config, "query_template")
+    assert config.query_template is None
+
+    assert hasattr(config, "datastore_autosave_every_n_updates")
+    assert config.datastore_autosave_every_n_updates is None
+
+    assert hasattr(config, "enable_cartesian_product")
+    assert config.enable_cartesian_product
 
 
 def test_missing_required_field__expects__raises_validation_error(resource_folder):

--- a/rre-tools/tests/resources/good_config_solr.yaml
+++ b/rre-tools/tests/resources/good_config_solr.yaml
@@ -21,3 +21,5 @@ output_format: "quepid"
 output_destination: "output"
 save_llm_explanation: true
 llm_explanation_destination: "output/rating_explanation.json"
+datastore_autosave_every_n_updates: 50
+enable_cartesian_product: false


### PR DESCRIPTION
DAGE-119: [Jira ticket](https://sease.atlassian.net/browse/DAGE-119)

`enable_cartesian_product` defaults to 'true', so the previous logic hasn't changed. Now this parameter can be used to turn off Cartesian product scoring between all queries and documents used to generate queries.

