### PR TITLE
DAGE-122: added escape function to SolrSearchEngine and applied when retrieving doc using the template

### DIFF
--- a/rre-tools/src/rre_tools/shared/search_engines/search_engine_base.py
+++ b/rre-tools/src/rre_tools/shared/search_engines/search_engine_base.py
@@ -9,10 +9,24 @@ from rre_tools.shared.models.document import Document
 NUMBER_OF_DOCS_EACH_FETCH = 100
 
 class BaseSearchEngine(ABC):
+
+    SPECIAL_CHARS: set[str] = {'\\', '+', '-', '!', '(', ')', ':', '^', '[', ']', '"',
+                               '{', '}', '~', '*', '?', '|', '&', '/'}
+
     def __init__(self, endpoint: HttpUrl):
         self.endpoint = HttpUrl(endpoint)
         self.QUERY_PLACEHOLDER = "$query"
         self.UNIQUE_KEY = 'id'
+
+    @staticmethod
+    def escape(string: str) -> str:
+        """Escape special characters used in query syntax."""
+        sb = []
+        for c in string:
+            if c in BaseSearchEngine.SPECIAL_CHARS:
+                sb.append('\\')
+            sb.append(c)
+        return ''.join(sb)
 
     def fetch_all(self, doc_fields: List[str]) -> Iterator[Document]:
         """Extract all documents from search engine in batches.

--- a/rre-tools/src/rre_tools/shared/search_engines/solr_search_engine.py
+++ b/rre-tools/src/rre_tools/shared/search_engines/solr_search_engine.py
@@ -19,8 +19,6 @@ class SolrSearchEngine(BaseSearchEngine):
     """
     Solr implementation to search into a given collection
     """
-    SPECIAL_CHARS: set[str] = {'\\', '+', '-', '!', '(', ')', ':', '^', '[', ']', '"',
-                     '{', '}', '~', '*', '?', '|', '&', '/'}
 
     def __init__(self, endpoint: HttpUrl):
         super().__init__(endpoint)
@@ -29,21 +27,11 @@ class SolrSearchEngine(BaseSearchEngine):
         self.UNIQUE_KEY = requests.get(urljoin(self.endpoint.encoded_string(), 'schema/uniquekey')).json()['uniqueKey']
         log.debug(f"uniqueKey found: {self.UNIQUE_KEY}")
 
-
     @property
     def _fetch_all_payload(self) -> Dict[str, Any]:
         return {
             'q': '*:*',
         }
-    @staticmethod
-    def escape(string: str) -> str:
-        """Escape special characters used in query syntax."""
-        sb = []
-        for c in string:
-            if c in SolrSearchEngine.SPECIAL_CHARS:
-                sb.append('\\')
-            sb.append(c)
-        return ''.join(sb)
 
     def _unify_fields(self, doc_fields: List[str]) -> str:
         fields = doc_fields if self.UNIQUE_KEY in doc_fields else doc_fields + [self.UNIQUE_KEY]

--- a/rre-tools/tests/shared/search_engines/test_base_search_engine.py
+++ b/rre-tools/tests/shared/search_engines/test_base_search_engine.py
@@ -1,0 +1,25 @@
+from rre_tools.shared.search_engines import BaseSearchEngine
+
+
+def test_escape_no_special_chars():
+    assert BaseSearchEngine.escape("hello world") == "hello world"
+
+def test_escape_basic_specials():
+    assert BaseSearchEngine.escape("a+b") == "a\\+b"
+    assert BaseSearchEngine.escape("field:value") == "field\\:value"
+    assert BaseSearchEngine.escape("(test)") == "\\(test\\)"
+
+def test_escape_multiple_specials():
+    assert BaseSearchEngine.escape("a+b-(c*d)?") == "a\\+b\\-\\(c\\*d\\)\\?"
+    assert BaseSearchEngine.escape("[range]~{json}") == "\\[range\\]\\~\\{json\\}"
+
+def test_escape_with_backslash():
+    assert BaseSearchEngine.escape("path\\to/file") == "path\\\\to\\/file"
+
+def test_escape_quotes():
+    assert BaseSearchEngine.escape('"phrase" AND title:book') == '\\"phrase\\" AND title\\:book'
+
+def test_escape_all_special_chars():
+    all_specials = r'\+-!():^[]"{}~*?|&/'
+    expected = ''.join(['\\' + c for c in all_specials])
+    assert BaseSearchEngine.escape(all_specials) == expected

--- a/rre-tools/tests/shared/search_engines/test_solr_search_engine.py
+++ b/rre-tools/tests/shared/search_engines/test_solr_search_engine.py
@@ -127,3 +127,27 @@ def test_solr_search_engine_negative_post_fetch_for_evaluation__expects__raises_
 def test_solr_search_engine_bad_url__expects__raises_validation_error():
     with pytest.raises(ValidationError):
         _ = SolrSearchEngine("fake-NONurl")
+
+
+def test_escape_no_special_chars():
+    assert SolrSearchEngine.escape("hello world") == "hello world"
+
+def test_escape_basic_specials():
+    assert SolrSearchEngine.escape("a+b") == "a\\+b"
+    assert SolrSearchEngine.escape("field:value") == "field\\:value"
+    assert SolrSearchEngine.escape("(test)") == "\\(test\\)"
+
+def test_escape_multiple_specials():
+    assert SolrSearchEngine.escape("a+b-(c*d)?") == "a\\+b\\-\\(c\\*d\\)\\?"
+    assert SolrSearchEngine.escape("[range]~{json}") == "\\[range\\]\\~\\{json\\}"
+
+def test_escape_with_backslash():
+    assert SolrSearchEngine.escape("path\\to/file") == "path\\\\to\\/file"
+
+def test_escape_quotes():
+    assert SolrSearchEngine.escape('"phrase" AND title:book') == '\\"phrase\\" AND title\\:book'
+
+def test_escape_all_special_chars():
+    all_specials = r'\+-!():^[]"{}~*?|&/'
+    expected = ''.join(['\\' + c for c in all_specials])
+    assert SolrSearchEngine.escape(all_specials) == expected

--- a/rre-tools/tests/shared/search_engines/test_solr_search_engine.py
+++ b/rre-tools/tests/shared/search_engines/test_solr_search_engine.py
@@ -127,27 +127,3 @@ def test_solr_search_engine_negative_post_fetch_for_evaluation__expects__raises_
 def test_solr_search_engine_bad_url__expects__raises_validation_error():
     with pytest.raises(ValidationError):
         _ = SolrSearchEngine("fake-NONurl")
-
-
-def test_escape_no_special_chars():
-    assert SolrSearchEngine.escape("hello world") == "hello world"
-
-def test_escape_basic_specials():
-    assert SolrSearchEngine.escape("a+b") == "a\\+b"
-    assert SolrSearchEngine.escape("field:value") == "field\\:value"
-    assert SolrSearchEngine.escape("(test)") == "\\(test\\)"
-
-def test_escape_multiple_specials():
-    assert SolrSearchEngine.escape("a+b-(c*d)?") == "a\\+b\\-\\(c\\*d\\)\\?"
-    assert SolrSearchEngine.escape("[range]~{json}") == "\\[range\\]\\~\\{json\\}"
-
-def test_escape_with_backslash():
-    assert SolrSearchEngine.escape("path\\to/file") == "path\\\\to\\/file"
-
-def test_escape_quotes():
-    assert SolrSearchEngine.escape('"phrase" AND title:book') == '\\"phrase\\" AND title\\:book'
-
-def test_escape_all_special_chars():
-    all_specials = r'\+-!():^[]"{}~*?|&/'
-    expected = ''.join(['\\' + c for c in all_specials])
-    assert SolrSearchEngine.escape(all_specials) == expected


### PR DESCRIPTION
DAGE-122: [Jira ticket](https://sease.atlassian.net/browse/DAGE-122)

Reference for the function: [SolrQueryParserBase.html#escape](https://github.com/apache/solr/blob/98e30eee8f0107381d9b1210fdf33aaeeb8008f5/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java#L992)

Implemented the function to add an escape to special characters and avoid having incongruence due to wildcards. Added also tests to keep consistency.

