### PR TITLE
Dataset-generator: allow search_engine_type=vespa and default vespa_schema to collection_name

### DIFF
--- a/rre-tools/src/rre_tools/dataset_generator/config.py
+++ b/rre-tools/src/rre_tools/dataset_generator/config.py
@@ -114,11 +114,10 @@ class Config(BaseModel):
     def search_engine_collection_endpoint(self) -> HttpUrl:
         """
         Returns the collection endpoint URL for the search engine.
-        For Vespa: uses vespa_schema instead of collection_name in the endpoint.
+        For Vespa: uses vespa_schema in the endpoint, defaulting to collection_name.
         """
         if self.search_engine_type == "vespa":
-            # For Vespa: use vespa_schema in the endpoint path
-            schema_name = self.vespa_schema or "doc"
+            schema_name = self.vespa_schema or self.collection_name
             return HttpUrl(urljoin(self.search_engine_url.encoded_string() + "/", schema_name + "/"))
         else:
             # For other engines: use collection_name
@@ -135,9 +134,9 @@ class Config(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def check_vespa_fields_required(self) -> "Config":
+    def default_vespa_schema_to_collection_name(self) -> "Config":
         if self.search_engine_type == "vespa" and not self.vespa_schema:
-            raise ValueError("vespa_schema is required when search_engine_type='vespa'")
+            self.vespa_schema = self.collection_name
         return self
 
     @classmethod

--- a/rre-tools/src/rre_tools/dataset_generator/main.py
+++ b/rre-tools/src/rre_tools/dataset_generator/main.py
@@ -85,10 +85,23 @@ def generate_and_add_queries(config: Config, data_store: DataStore, llm_service:
             )
 
 
+def get_queries_within_budget(config: Config, data_store: DataStore) -> List[Query]:
+    queries = data_store.get_queries()
+    queries_within_budget = queries[:config.num_queries_needed]
+    if len(queries) > len(queries_within_budget):
+        log.info(
+            "Processing %s of %s queries due to num_queries_needed=%s",
+            len(queries_within_budget),
+            len(queries),
+            config.num_queries_needed,
+        )
+    return queries_within_budget
+
+
 def add_cartesian_product_scores(config: Config, data_store: DataStore, llm_service: LLMService) -> None:
     """Complete the (query, doc) matrix with LLM scores."""
     log.debug("Cartesian product is enabled, so adding cartesian product scores")
-    for query_obj in data_store.get_queries():
+    for query_obj in get_queries_within_budget(config, data_store):
         for doc_obj in data_store.get_cartesian_prod_docs():
             if not data_store.has_rating_score(query_obj.id, doc_obj.id):
                 score_resp: LLMScoreResponse = llm_service.generate_score(
@@ -105,7 +118,7 @@ def expand_docset_with_search_engine_top_k(config: Config, data_store: DataStore
     """Retrieve docs for each query and score the (q, doc) pairs."""
     if config.query_template is not None:
         log.debug(f"Searching for documents with query template in {config.query_template}")
-        for query_obj in data_store.get_queries():
+        for query_obj in get_queries_within_budget(config, data_store):
             docs_eval: List[Document] = search_engine.fetch_for_evaluation(
                 keyword=query_obj.text, query_template=config.query_template, doc_fields=config.doc_fields
             )

--- a/rre-tools/src/rre_tools/shared/search_engines/search_engine_factory.py
+++ b/rre-tools/src/rre_tools/shared/search_engines/search_engine_factory.py
@@ -5,6 +5,7 @@ from rre_tools.shared.search_engines.opensearch_engine import OpenSearchEngine
 from rre_tools.shared.search_engines.search_engine_base import BaseSearchEngine
 from rre_tools.shared.search_engines.solr_search_engine import SolrSearchEngine
 from rre_tools.shared.search_engines.elasticsearch_search_engine import ElasticsearchSearchEngine
+from rre_tools.shared.search_engines.vespa_search_engine import VespaSearchEngine
 
 import logging
 
@@ -15,7 +16,8 @@ class SearchEngineFactory:
     SEARCH_ENGINE_REGISTRY: Dict[str, Type[BaseSearchEngine]] = {
         "solr": SolrSearchEngine,
         "opensearch": OpenSearchEngine,
-        "elasticsearch": ElasticsearchSearchEngine
+        "elasticsearch": ElasticsearchSearchEngine,
+        "vespa": VespaSearchEngine,
     }
 
     @classmethod

--- a/rre-tools/tests/dataset_generator/test_config_dataset_generator.py
+++ b/rre-tools/tests/dataset_generator/test_config_dataset_generator.py
@@ -77,6 +77,29 @@ def test_mteb_config__expects__successful_load(resource_folder):
     assert mteb_config.output_format == "mteb"
     assert mteb_config.output_destination == Path("output")
 
+
+def test_vespa_config_without_schema__expects__schema_defaults_to_collection_name(tmp_path):
+    cfg_text = (
+        "search_engine_type: \"vespa\"\n"
+        "collection_name: \"movie\"\n"
+        "search_engine_url: \"http://localhost:8080/search/\"\n"
+        "number_of_docs: 2\n"
+        "doc_fields: [\"title\"]\n"
+        "num_queries_needed: 2\n"
+        "relevance_scale: \"binary\"\n"
+        "llm_configuration_file: \"tests/resources/llm_config.yaml\"\n"
+        "output_format: \"quepid\"\n"
+        "output_destination: \"output\"\n"
+    )
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(cfg_text, encoding="utf-8")
+
+    cfg = Config.load(str(cfg_path))
+
+    assert cfg.vespa_schema == "movie"
+    assert cfg.search_engine_collection_endpoint == HttpUrl("http://localhost:8080/search/movie/")
+
+
 def test_missing_both_templates_with_rre__expects__raises_validation_error(resource_folder):
     file_name = "missing_both_templates.yaml"
     with pytest.raises(ValidationError):

--- a/rre-tools/tests/dataset_generator/test_main_query_budget.py
+++ b/rre-tools/tests/dataset_generator/test_main_query_budget.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from rre_tools.dataset_generator.main import add_cartesian_product_scores, expand_docset_with_search_engine_top_k
+from rre_tools.shared.data_store import DataStore
+from rre_tools.shared.models import Document
+
+
+class FakeLLMService:
+    def __init__(self):
+        self.calls = []
+
+    def generate_score(self, document, query, relevance_scale, explanation=False):
+        self.calls.append((document.id, query, relevance_scale, explanation))
+        return SimpleNamespace(score=1, explanation=None, get_score=lambda: 1)
+
+
+class FakeSearchEngine:
+    def __init__(self):
+        self.queries = []
+
+    def fetch_for_evaluation(self, keyword, query_template, doc_fields):
+        self.queries.append(keyword)
+        return [Document(id=f"doc-{keyword}", fields={"title": [keyword]})]
+
+
+def _config(**overrides):
+    values = {
+        "num_queries_needed": 2,
+        "query_template": "select * from test where userInput(@kw)",
+        "doc_fields": ["title"],
+        "relevance_scale": "graded",
+        "save_llm_explanation": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_expand_docset_with_search_engine_top_k__expects__query_budget_respected():
+    data_store = DataStore(ignore_saved_data=True)
+    for query in ["q1", "q2", "q3"]:
+        data_store.add_query(query)
+
+    llm_service = FakeLLMService()
+    search_engine = FakeSearchEngine()
+
+    expand_docset_with_search_engine_top_k(_config(), data_store, llm_service, search_engine)
+
+    assert search_engine.queries == ["q1", "q2"]
+    assert [call[1] for call in llm_service.calls] == ["q1", "q2"]
+
+
+def test_add_cartesian_product_scores__expects__query_budget_respected():
+    data_store = DataStore(ignore_saved_data=True)
+    for query in ["q1", "q2", "q3"]:
+        data_store.add_query(query)
+    for doc_id in ["d1", "d2"]:
+        data_store.add_document(Document(id=doc_id, fields={"title": [doc_id]}, is_used_to_generate_queries=True))
+
+    llm_service = FakeLLMService()
+
+    add_cartesian_product_scores(_config(), data_store, llm_service)
+
+    assert [call[1] for call in llm_service.calls] == ["q1", "q1", "q2", "q2"]

--- a/rre-tools/tests/shared/search_engines/test_search_engine_factory.py
+++ b/rre-tools/tests/shared/search_engines/test_search_engine_factory.py
@@ -1,0 +1,21 @@
+import pytest
+from pydantic import HttpUrl
+
+from rre_tools.shared.search_engines import SearchEngineFactory, VespaSearchEngine
+
+
+def test_build_vespa__expects__vespa_search_engine():
+    search_engine = SearchEngineFactory.build(
+        search_engine_type="vespa",
+        endpoint=HttpUrl("http://localhost:8080/doc/"),
+    )
+
+    assert isinstance(search_engine, VespaSearchEngine)
+
+
+def test_build_unsupported_search_engine__expects__value_error():
+    with pytest.raises(ValueError, match="Unsupported search engine: unsupported"):
+        SearchEngineFactory.build(
+            search_engine_type="unsupported",
+            endpoint=HttpUrl("http://localhost:8080/doc/"),
+        )


### PR DESCRIPTION
This should make it a bit easier to use dataset-generator with Vespa.

search_engine_type=vespa didn't seem to work from the command line (uv run...) before this.

Vespa schema is the equivalent of a collection in Solr, so collection_name should be a good default. I don't know why one would override it, but it's still possible now.

Didn't want to be intrusive, it's my first contribution 🙈 

Let me know if you need me to change anything.