### PR TITLE
Dataset generator: queries from categories (facet results)

### DIFF
--- a/rre-tools/configs/dataset_generator/dataset_generator_config.yaml
+++ b/rre-tools/configs/dataset_generator/dataset_generator_config.yaml
@@ -45,6 +45,51 @@ queries: "templates/queries.txt"
 # Default: true; set to false to disable query generation from documents
 generate_queries_from_documents: true
 
+# (Optional) Generate queries from values of one or more configured fields.
+# Each entry in the list defines:
+#   - fields: array (currently only fields[0] is read); every field must also appear in doc_fields above
+#   - exactly one of:
+#       * values: explicit list of values typed by the user
+#       * values_query_template_file: path to an engine-native facet / aggregation / grouping template.
+#         The engine runs that query at generation time and uses its distinct values for fields[0].
+#         Supported shapes: a Solr request-params JSON dict, an ES/OpenSearch JSON request body, or a
+#         Vespa YQL grouping query. The template's limit (Solr facet.limit / ES-OS terms.size /
+#         Vespa max(N)) is the only knob.
+#   - query_text_template_file: (Optional) path to a plain-text natural-language template whose content
+#     includes the engine's query placeholder ('$query' for Solr/Elasticsearch/OpenSearch, '@kw' for
+#     Vespa — same convention as the engine retrieval query_template above). If omitted, each value is
+#     used directly as the query text (e.g. value "comedy" produces query "comedy").
+# Note: this is a *natural-language* query template (e.g., "$query movies"); it is intentionally distinct
+# from the engine retrieval query_template (Solr params JSON / Vespa YQL / etc.). Pointing this field — or
+# values_query_template_file — at the engine retrieval template is rejected at config load.
+# Budget interaction: if the rendered queries plus other sources exceed num_queries_needed, the surplus is
+# added to the datastore but skipped at scoring time. Duplicate rendered strings dedupe automatically.
+#
+# Explicit values:
+#category_queries:
+#  - fields: ["genres"]
+#    values: ["comedy", "action", "horror", "drama"]
+#    # Bare values: queries are "comedy", "action", "horror", "drama".
+#    # Add `query_text_template_file: "templates/genre_query.tmpl"` (with content like `$query movies`)
+#    # to render wrapped queries instead.
+#
+# Values discovered from the engine (Solr facet, ES/OpenSearch terms agg, or Vespa grouping):
+#   Solr — request-params JSON dict (NOT a Solr JSON Request API body):
+#category_queries:
+#  - fields: ["genres"]
+#    values_query_template_file: "templates/genre_facet_solr.json"
+#    query_text_template_file: "templates/genre_query.tmpl"
+#   Elasticsearch / OpenSearch — full JSON request body. Convention: the aggregation result key
+#   under `aggs` must equal fields[0] (the agg's internal terms.field can be a keyword subfield):
+#category_queries:
+#  - fields: ["genres"]
+#    values_query_template_file: "templates/genre_facet_es.json"
+#   Vespa — YQL only; engine wraps with hits=0 and presentation.format=json.
+#   The grouped field must be an `attribute` in the .sd schema:
+#category_queries:
+#  - fields: ["genres"]
+#    values_query_template_file: "templates/genre_facet_vespa.yql"
+
 # Total number of queries to generate (includes predefined queries, if any)
 num_queries_needed: 30
 

--- a/rre-tools/docs/dataset_generator/README.md
+++ b/rre-tools/docs/dataset_generator/README.md
@@ -16,6 +16,7 @@ directory (or modify the existing one). This file controls the entire generation
 >     - "solr"
 >     - "elasticsearch"
 >     - "opensearch"
+>     - "vespa"
 > - **collection_name**: Name of the search engine index/collection (e.g., "testcore", the one used in Docker containers)
 > - **search_engine_url**: URL of the search engine (e.g., "http://localhost:8983/solr/")
 > - **documents_filter**: Filter query to restrict the set of documents used to generate queries. If a field has more 
@@ -37,7 +38,89 @@ one fields, the documents are filtered for both fields (AND-like)
 > available, must be in a txt format (e.g., "queries.txt")
 > - **generate_queries_from_documents** (Optional): Whether to generate queries from documents. Default to `true`; set
 > to `false` to disable query generation from documents
-> - **num_queries_needed**: Total number of queries to generate, including predefined queries, if any (e.g., 20)
+> - **category_queries** (Optional): A list of category-derived query sources. Each entry generates queries from the
+> values of one configured field — for example, `genres=[comedy, action, ...]` produces queries like `"comedy"`,
+> `"action"` (or `"comedy movies"`, `"action movies"` if you wrap them via a template). These queries flow through
+> the same `DataStore` as user-supplied and LLM-generated queries, compose with `generate_queries_from_documents`,
+> and use the existing cartesian-product and top-K expansion paths for scoring.
+>
+>   Each entry has:
+>   - **`fields`** — array of field names. Currently only `fields[0]` is read; every field listed must also appear in
+>     `doc_fields` so the LLM scorer has evidence to grade against.
+>   - **Where the values come from** — exactly one of:
+>     - **`values`** — an explicit list typed by the user (e.g. `["comedy", "action"]`).
+>     - **`values_query_template_file`** — a path to an engine-native facet / aggregation / grouping template. The
+>       engine runs that query at generation time and uses its distinct values for `fields[0]`. The template's limit
+>       (Solr `facet.limit`, ES/OS `terms.size`, Vespa grouping `max(N)`) is the only knob.
+>   - **`query_text_template_file`** (Optional) — a plain-text natural-language template wrapping each value. If
+>     omitted, each value is the query text directly (`comedy` → query `"comedy"`). If provided, the file's contents
+>     must contain the engine's query placeholder — `$query` for Solr/Elasticsearch/OpenSearch, `@kw` for Vespa,
+>     matching the same convention as the engine retrieval `query_template` — and each value is substituted into the
+>     placeholder (e.g. `"$query movies"` + `comedy` → `"comedy movies"`).
+>
+>   **Examples — explicit values:**
+>   ```yaml
+>   # Bare values (queries: "comedy", "action", "horror", "drama")
+>   category_queries:
+>     - fields: ["genres"]
+>       values: ["comedy", "action", "horror", "drama"]
+>
+>   # Wrapped via template (queries: "comedy movies", ...) — Solr placeholder
+>   category_queries:
+>     - fields: ["genres"]
+>       values: ["comedy", "action", "horror", "drama"]
+>       query_text_template_file: "templates/genre_query.tmpl"  # contents: $query movies
+>   ```
+>
+>   **Examples — values discovered from the engine.** Replace `values` with `values_query_template_file`. Each engine
+>   reads the template in the same shape it already uses for retrieval, so you don't learn a second convention per
+>   engine:
+>   - **Solr** — the file is a JSON dict of Solr request parameters (`q`, `facet`, `facet.field`, `facet.limit`,
+>     `rows`). The engine injects `wt=json` and GETs `/select` with `params=<the dict>`. Not a Solr JSON Request API
+>     body. Sample: `templates/genre_facet_solr.json`.
+>   - **Elasticsearch / OpenSearch** — the file is a full JSON request body POSTed to `_search`. **Convention:** in the
+>     *request* body the terms aggregation is declared under `aggs` with a name that must equal `fields[0]` (e.g.
+>     `genres` in the shipped samples); Elasticsearch/OpenSearch return buckets under *response* key `aggregations`
+>     with that same name. The agg's internal `terms.field` may be a keyword subfield (`genres.keyword`) without
+>     requiring `genres.keyword` to be in `doc_fields`. Keyed-bucket aggregations (`"keyed": true`) are not supported.
+>     Samples: `templates/genre_facet_es.json`, `templates/genre_facet_opensearch.json`.
+>   - **Vespa** — the file is YQL only; the engine wraps it with `hits=0` and `presentation.format=json` (YQL itself
+>     can't express those). **Precondition:** the grouped field must be declared as an `attribute` in the `.sd`
+>     schema; a non-attribute field will fail at the engine, not at config-load. Sample:
+>     `templates/genre_facet_vespa.yql`.
+>
+>   ```yaml
+>   # Solr
+>   category_queries:
+>     - fields: ["genres"]
+>       values_query_template_file: "templates/genre_facet_solr.json"
+>       query_text_template_file: "templates/genre_query.tmpl"  # optional
+>
+>   # Elasticsearch / OpenSearch
+>   category_queries:
+>     - fields: ["genres"]
+>       values_query_template_file: "templates/genre_facet_es.json"
+>
+>   # Vespa
+>   category_queries:
+>     - fields: ["genres"]
+>       values_query_template_file: "templates/genre_facet_vespa.yql"
+>   ```
+>
+>   Notes: the category templates (natural-language string and value-discovery payload) are both distinct from the
+>   engine retrieval `query_template` (Solr params JSON / Vespa YQL retrieval payload) — pointing either at the engine
+>   retrieval file is rejected at config load, as is pointing `values_query_template_file` at the same path as
+>   `query_text_template_file` on the same source. Discovered values are normalized to non-empty stripped scalar
+>   strings; container-typed bucket keys (nested aggregations) raise rather than landing as nonsense queries. If more
+>   category values are configured (or discovered) than `num_queries_needed`, the surplus is added to the datastore
+>   but skipped at scoring time.
+> - **num_queries_needed**: Total number of queries to generate, including predefined queries, if any (e.g., 20).
+> When the in-memory queries (user-supplied + category + LLM-generated + previously-cached) exceed this number, the
+> selection is prioritized so that fresh sources from this run win over cached entries. Priority order:
+> user-supplied = category > LLM-generated > queries loaded from `resources/tmp/datastore.json`. Within each tier,
+> insertion order is preserved. Practical implication: if your cache already contains `num_queries_needed` queries from
+> a previous run, the fresh user/category queries you add this run still make the cut; previously they were silently
+> dropped because selection used raw insertion order.
 > - **relevance_scale**: Relevance scale used for scoring document relevance
 >   - accepted values: "binary" or "graded", where
 >     - binary: 0 (not relevant), 1 (relevant)

--- a/rre-tools/src/rre_tools/dataset_generator/config.py
+++ b/rre-tools/src/rre_tools/dataset_generator/config.py
@@ -5,9 +5,72 @@ import logging
 from pathlib import Path
 from urllib.parse import urljoin
 
+from rre_tools.shared.search_engines import SearchEngineFactory
 from rre_tools.shared.writers import WriterConfig
 
 log = logging.getLogger(__name__)
+
+
+class CategoryQuerySource(BaseModel):
+    fields: List[str] = Field(..., min_length=1,
+                              description="Fields used to derive category values. Only fields[0] is read.")
+    values: Optional[List[str]] = Field(
+        None,
+        min_length=1,
+        description="Explicit list of values used to render category queries. Mutually exclusive with "
+                    "values_query_template_file (set exactly one)."
+    )
+    values_query_template_file: Optional[FilePath] = Field(
+        None,
+        description="Optional path to an engine-native value-discovery template "
+                    "(Solr request-params JSON / ES or OpenSearch JSON request body / Vespa YQL). "
+                    "When set, the engine returns the distinct values for fields[0] at run time. "
+                    "Mutually exclusive with values (set exactly one)."
+    )
+    query_text_template_file: Optional[FilePath] = Field(
+        None,
+        description="Optional path to a plain-text natural-language template. Contents must contain the "
+                    "engine's query placeholder ('@kw' for Vespa, '$query' for Solr/Elasticsearch/OpenSearch). "
+                    "If omitted, each value is used directly as the query text (e.g. 'comedy', 'action')."
+    )
+
+    @field_validator('fields')
+    @classmethod
+    def check_no_empty_fields(cls, value_field: List[str]) -> List[str]:
+        if any(not f.strip() for f in value_field):
+            raise ValueError("category_queries.fields cannot contain empty strings.")
+        return value_field
+
+    @field_validator('values')
+    @classmethod
+    def check_no_empty_values(cls, value_field: Optional[List[str]]) -> Optional[List[str]]:
+        # Field is now Optional so the validator must accept None — Pydantic still routes
+        # None through the field validator on a typed-Optional field.
+        if value_field is None:
+            return value_field
+        if any(not v.strip() for v in value_field):
+            raise ValueError("category_queries.values cannot contain empty strings.")
+        return value_field
+
+    @model_validator(mode="after")
+    def validate_single_field(self) -> "CategoryQuerySource":
+        if len(self.fields) > 1:
+            raise ValueError(
+                "category_queries.fields with more than one entry is not yet supported."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_exactly_one_value_source(self) -> "CategoryQuerySource":
+        """Exactly one of `values` (explicit list) or `values_query_template_file`
+        (engine value-discovery template) must be set."""
+        provided = sum(x is not None for x in (self.values, self.values_query_template_file))
+        if provided != 1:
+            raise ValueError(
+                "category_queries entries must set exactly one of 'values' (explicit list) or "
+                "'values_query_template_file' (engine facet/aggregation/grouping template)."
+            )
+        return self
 
 
 class Config(BaseModel):
@@ -26,7 +89,12 @@ class Config(BaseModel):
     number_of_docs: int = Field(..., gt=0, description="Number of documents to retrieve from the search engine.")
     doc_fields: List[str] = Field(..., min_length=1, description="Fields used for context and scoring.")
     queries: Optional[FilePath] = Field(None, description="Optional file containing predefined queries.")
-    generate_queries_from_documents: Optional[bool] = True
+    generate_queries_from_documents: bool = True
+    category_queries: Optional[List[CategoryQuerySource]] = Field(
+        None,
+        description="Optional list of category-derived query sources. Each source renders queries from "
+                    "values of a configured field through a natural-language template."
+    )
     num_queries_needed: int = Field(..., gt=0, description="Total number of queries to generate.")
     relevance_scale: Literal['binary', 'graded']
     llm_configuration_file: FilePath = Field(..., description="Path to the LLM configuration file.")
@@ -137,6 +205,116 @@ class Config(BaseModel):
     def default_vespa_schema_to_collection_name(self) -> "Config":
         if self.search_engine_type == "vespa" and not self.vespa_schema:
             self.vespa_schema = self.collection_name
+        return self
+
+    @model_validator(mode="after")
+    def validate_category_query_fields_in_doc_fields(self) -> "Config":
+        if self.category_queries is None:
+            return self
+        doc_fields_set = set(self.doc_fields)
+        for source in self.category_queries:
+            missing = [f for f in source.fields if f not in doc_fields_set]
+            if missing:
+                raise ValueError(
+                    f"category_queries field(s) {missing} must also be present in doc_fields. "
+                    f"The LLM scorer only sees fields fetched into the Document."
+                )
+        return self
+
+    @property
+    def category_query_placeholder(self) -> str:
+        """Placeholder used inside category-query natural-language templates.
+
+        Reuses the engine class's `QUERY_PLACEHOLDER` so the category template follows the
+        same convention as the engine retrieval template ('$query' for Solr/ES/OpenSearch,
+        '@kw' for Vespa).
+        """
+        return SearchEngineFactory.SEARCH_ENGINE_REGISTRY[self.search_engine_type].QUERY_PLACEHOLDER
+
+    # NOTE on validator ordering: Pydantic runs `model_validator(mode="after")` validators in
+    # declaration order. All path-collision validators must come BEFORE content-reading
+    # validators (e.g. validate_category_query_template_placeholders), so that pointing
+    # `query_text_template_file` at a value-discovery JSON file produces the informative
+    # "different concepts" error rather than a misleading "missing placeholder" one.
+
+    @model_validator(mode="after")
+    def validate_category_template_paths_distinct(self) -> "Config":
+        """Reject path collisions between category-source template files and other templates.
+
+        Three rejected collisions per `CategoryQuerySource`:
+          1. `query_text_template_file` == top-level `query_template` / `rre_query_template`
+             — prevents using the engine retrieval payload as a natural-language template:
+             substitution would dump Solr params JSON / Vespa YQL as the query string.
+          2. `values_query_template_file` == top-level `query_template` / `rre_query_template`
+             — same kind of misuse on the value-discovery side.
+          3. `values_query_template_file` == `query_text_template_file` on the same source
+             — the two fields cohabit on `CategoryQuerySource`, so swapping them is materially
+             more likely than a generic file-path collision.
+        """
+        if self.category_queries is None:
+            return self
+        engine_template_paths = {
+            p.resolve() for p in (self.query_template, self.rre_query_template) if p is not None
+        }
+        for source in self.category_queries:
+            qt_path = source.query_text_template_file.resolve() if source.query_text_template_file else None
+            vq_path = source.values_query_template_file.resolve() if source.values_query_template_file else None
+
+            if qt_path is not None and qt_path in engine_template_paths:
+                raise ValueError(
+                    f"category_queries.query_text_template_file '{source.query_text_template_file}' "
+                    f"points at the same file as the engine retrieval 'query_template' / "
+                    f"'rre_query_template'. These are different concepts: the engine template is the "
+                    f"retrieval payload (e.g. Vespa YQL, Solr params JSON, ES/OS request body); "
+                    f"the category template is a "
+                    f"natural-language query string template like '{self.category_query_placeholder} "
+                    f"movies'. Create a separate plain-text file containing the placeholder "
+                    f"('{self.category_query_placeholder}') and any surrounding wording, and point "
+                    f"'query_text_template_file' at that."
+                )
+
+            if vq_path is not None and vq_path in engine_template_paths:
+                raise ValueError(
+                    f"category_queries.values_query_template_file '{source.values_query_template_file}' "
+                    f"points at the same file as the engine retrieval 'query_template' / "
+                    f"'rre_query_template'. These are different concepts: the engine retrieval "
+                    f"template fetches documents for a given keyword, while the value-discovery "
+                    f"template runs a facet / aggregation / grouping query that returns a list of "
+                    f"distinct values for the configured field."
+                )
+
+            if vq_path is not None and qt_path is not None and vq_path == qt_path:
+                raise ValueError(
+                    f"category_queries.values_query_template_file and category_queries."
+                    f"query_text_template_file on the same source point at the same file "
+                    f"('{source.values_query_template_file}'). These are different concepts: "
+                    f"values_query_template_file is the engine value-discovery payload (Solr "
+                    f"params dict / ES or OpenSearch JSON body / Vespa YQL) that returns the list "
+                    f"of distinct values; query_text_template_file is a plain-text natural-"
+                    f"language template (e.g. '{self.category_query_placeholder} movies') that "
+                    f"wraps each value into a query string."
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_category_query_template_placeholders(self) -> "Config":
+        if self.category_queries is None:
+            return self
+        placeholder = self.category_query_placeholder
+        for source in self.category_queries:
+            if source.query_text_template_file is None:
+                continue  # bare-value mode: nothing to validate
+            content = source.query_text_template_file.read_text(encoding="utf-8")
+            if placeholder not in content:
+                raise ValueError(
+                    f"query_text_template_file '{source.query_text_template_file}' must contain the "
+                    f"literal placeholder '{placeholder}' (the convention for "
+                    f"search_engine_type='{self.search_engine_type}'). This file is the natural-"
+                    f"language query template used to render category queries (e.g. "
+                    f"'{placeholder} movies'); it is distinct from the engine retrieval template "
+                    f"configured under top-level 'query_template' (Solr params JSON / Vespa YQL / etc.). "
+                    f"Omit this field entirely to use each value as the query text directly."
+                )
         return self
 
     @classmethod

--- a/rre-tools/src/rre_tools/dataset_generator/config.py
+++ b/rre-tools/src/rre_tools/dataset_generator/config.py
@@ -114,11 +114,10 @@ class Config(BaseModel):
     def search_engine_collection_endpoint(self) -> HttpUrl:
         """
         Returns the collection endpoint URL for the search engine.
-        For Vespa: uses vespa_schema instead of collection_name in the endpoint.
+        For Vespa: uses vespa_schema in the endpoint, defaulting to collection_name.
         """
         if self.search_engine_type == "vespa":
-            # For Vespa: use vespa_schema in the endpoint path
-            schema_name = self.vespa_schema or "doc"
+            schema_name = self.vespa_schema or self.collection_name
             return HttpUrl(urljoin(self.search_engine_url.encoded_string() + "/", schema_name + "/"))
         else:
             # For other engines: use collection_name
@@ -135,9 +134,9 @@ class Config(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def check_vespa_fields_required(self) -> "Config":
+    def default_vespa_schema_to_collection_name(self) -> "Config":
         if self.search_engine_type == "vespa" and not self.vespa_schema:
-            raise ValueError("vespa_schema is required when search_engine_type='vespa'")
+            self.vespa_schema = self.collection_name
         return self
 
     @classmethod

--- a/rre-tools/src/rre_tools/dataset_generator/main.py
+++ b/rre-tools/src/rre_tools/dataset_generator/main.py
@@ -85,10 +85,23 @@ def generate_and_add_queries(config: Config, data_store: DataStore, llm_service:
             )
 
 
+def get_queries_within_budget(config: Config, data_store: DataStore) -> List[Query]:
+    queries = data_store.get_queries()
+    queries_within_budget = queries[:config.num_queries_needed]
+    if len(queries) > len(queries_within_budget):
+        log.info(
+            "Processing %s of %s queries due to num_queries_needed=%s",
+            len(queries_within_budget),
+            len(queries),
+            config.num_queries_needed,
+        )
+    return queries_within_budget
+
+
 def add_cartesian_product_scores(config: Config, data_store: DataStore, llm_service: LLMService) -> None:
     """Complete the (query, doc) matrix with LLM scores."""
     log.debug("Cartesian product is enabled, so adding cartesian product scores")
-    for query_obj in data_store.get_queries():
+    for query_obj in get_queries_within_budget(config, data_store):
         for doc_obj in data_store.get_cartesian_prod_docs():
             if not data_store.has_rating_score(query_obj.id, doc_obj.id):
                 score_resp: LLMScoreResponse = llm_service.generate_score(
@@ -105,7 +118,7 @@ def expand_docset_with_search_engine_top_k(config: Config, data_store: DataStore
     """Retrieve docs for each query and score the (q, doc) pairs."""
     if config.query_template is not None:
         log.debug(f"Searching for documents with query template in {config.query_template}")
-        for query_obj in data_store.get_queries():
+        for query_obj in get_queries_within_budget(config, data_store):
             docs_eval: List[Document] = search_engine.fetch_for_evaluation(
                 keyword=query_obj.text, query_template=config.query_template, doc_fields=config.doc_fields
             )

--- a/rre-tools/src/rre_tools/dataset_generator/main.py
+++ b/rre-tools/src/rre_tools/dataset_generator/main.py
@@ -15,6 +15,7 @@ from logging import Logger, getLogger
 from rre_tools.shared.logger import setup_logging
 from rre_tools.dataset_generator.llm import LLMConfig, LLMService, LLMServiceFactory
 from rre_tools.shared.models import Document, Query
+from rre_tools.shared.models.query import SOURCE_PRIORITY
 from rre_tools.shared.writers import WriterFactory, AbstractWriter, WriterConfig
 from rre_tools.shared.search_engines import SearchEngineFactory, BaseSearchEngine
 from rre_tools.shared.data_store import DataStore
@@ -22,6 +23,7 @@ from rre_tools.shared.utils import join_fields_as_text
 
 from rre_tools.dataset_generator.models import LLMQueryResponse, LLMScoreResponse
 from rre_tools.dataset_generator.config import Config
+from rre_tools.dataset_generator.query_sources import add_category_queries
 
 log: Logger = getLogger(__name__)
 
@@ -46,13 +48,16 @@ def add_user_queries(config: Config, data_store: DataStore) -> None:
             for line in file:
                 clean_line = line.strip()
                 if clean_line:
-                    data_store.add_query(clean_line)
+                    data_store.add_query(clean_line, source="user")
             log.info(f"Added user-defined queries from file={config.queries}")
 
 
-def generate_and_add_queries(config: Config, data_store: DataStore, llm_service: LLMService,
-                             search_engine: BaseSearchEngine) -> None:
-    """Retrieve docs and generate queries with LLM Service. Adds docs, queries and ratings to the datastore."""
+def fetch_and_add_seed_documents(config: Config, data_store: DataStore,
+                                 search_engine: BaseSearchEngine) -> List[Document]:
+    """Fetch seed documents from the search engine and ensure each is flagged as a cartesian seed.
+
+    Returns the list of fetched documents so callers can reuse them without re-fetching.
+    """
     docs_to_generate_queries: List[Document] = search_engine.fetch_for_query_generation(
         documents_filter=config.documents_filter,
         number_of_docs=config.number_of_docs,
@@ -62,23 +67,49 @@ def generate_and_add_queries(config: Config, data_store: DataStore, llm_service:
     for doc in docs_to_generate_queries:
         doc.is_used_to_generate_queries = True
         data_store.add_document(doc)
+        # Cache hit path: add_document() returned early without updating the stored object.
+        data_store.mark_document_as_query_seed(doc.id)
 
-    remaining = max(0, config.num_queries_needed - len(data_store.get_queries()))
+    return docs_to_generate_queries
+
+
+def generate_and_add_queries_from_documents(config: Config, data_store: DataStore, llm_service: LLMService,
+                                            seed_docs: List[Document]) -> None:
+    """Generate queries with the LLM service from already-fetched seed documents.
+
+    Adds queries and pre-rates each generated query against its source document with the max
+    label from the relevance scale: a query produced from a doc is by definition a perfect match.
+
+    Budget accounting honors the source-priority ordering used by `get_queries_within_budget`:
+    only queries with priority <= 'llm' (i.e. user/category/llm) consume budget slots here.
+    Cached queries do *not* — they're displaceable, so a saturated cache must not block fresh
+    LLM generation.
+    """
+    llm_threshold = SOURCE_PRIORITY["llm"]
+
+    def _slots_filled() -> int:
+        return sum(1 for q in data_store.get_queries() if SOURCE_PRIORITY[q.source] <= llm_threshold)
+
+    remaining = max(0, config.num_queries_needed - _slots_filled())
     if remaining == 0:
         return
 
     num_queries_per_doc: int = int((remaining // max(1, config.number_of_docs)) + 1)  # always greater or equal to 1
-    log.debug(f"Number of documents retrieved for generation: {len(docs_to_generate_queries)}")
+    log.debug(f"Number of documents retrieved for generation: {len(seed_docs)}")
     log.debug(f"Pending queries to generate: {remaining}")
     log.debug(f"Number of queries per document: {num_queries_per_doc}")
 
-    for doc in docs_to_generate_queries:
+    for doc in seed_docs:
+        # Re-check between outer iterations so we don't burn an LLM call on doc N+1
+        # after the inner loop on doc N already filled the budget.
+        if _slots_filled() >= config.num_queries_needed:
+            return
         query_response: LLMQueryResponse = llm_service.generate_queries(doc, num_queries_per_doc,
                                                                         config.max_query_terms)
         for query_ in query_response.get_queries():
-            if len(data_store.get_queries()) >= config.num_queries_needed:
+            if _slots_filled() >= config.num_queries_needed:
                 return
-            query_obj: Query = data_store.add_query(query_)
+            query_obj: Query = data_store.add_query(query_, source="llm")
             data_store.create_rating_score(
                 query_obj.id, doc.id, max(config.relevance_label_set),
                 "Default max rating is assigned because the query is generated by the document"
@@ -86,8 +117,16 @@ def generate_and_add_queries(config: Config, data_store: DataStore, llm_service:
 
 
 def get_queries_within_budget(config: Config, data_store: DataStore) -> List[Query]:
+    """Pick the per-run query budget, prioritizing fresh sources over cached ones.
+
+    Stable sort by `(SOURCE_PRIORITY[query.source], insertion_index)` so user/category
+    queries asserted this run always make the cut before queries loaded from the disk
+    cache, while preserving insertion order within each priority tier.
+    """
     queries = data_store.get_queries()
-    queries_within_budget = queries[:config.num_queries_needed]
+    indexed = list(enumerate(queries))
+    indexed.sort(key=lambda iq: (SOURCE_PRIORITY[iq[1].source], iq[0]))
+    queries_within_budget = [q for _, q in indexed[:config.num_queries_needed]]
     if len(queries) > len(queries_within_budget):
         log.info(
             "Processing %s of %s queries due to num_queries_needed=%s",
@@ -158,8 +197,18 @@ def main() -> None:
     # load user queries
     add_user_queries(config, data_store)
 
-    # generate more queries with LLM service if needed
-    generate_and_add_queries(config, data_store, service, search_engine)
+    # render category-derived queries from each source's explicit values, or from values
+    # discovered by the engine when values_query_template_file is set instead of values.
+    add_category_queries(config, data_store, search_engine)
+
+    # fetch seed documents only when something downstream actually needs them
+    seed_docs: List[Document] = []
+    if config.enable_cartesian_product or config.generate_queries_from_documents:
+        seed_docs = fetch_and_add_seed_documents(config, data_store, search_engine)
+
+    # generate more queries with LLM service from the same seed documents, if enabled
+    if config.generate_queries_from_documents:
+        generate_and_add_queries_from_documents(config, data_store, service, seed_docs)
 
     # score initial docset
     if config.enable_cartesian_product:

--- a/rre-tools/src/rre_tools/dataset_generator/query_sources/__init__.py
+++ b/rre-tools/src/rre_tools/dataset_generator/query_sources/__init__.py
@@ -1,0 +1,3 @@
+from rre_tools.dataset_generator.query_sources.category_queries import add_category_queries
+
+__all__ = ["add_category_queries"]

--- a/rre-tools/src/rre_tools/dataset_generator/query_sources/category_queries.py
+++ b/rre-tools/src/rre_tools/dataset_generator/query_sources/category_queries.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from logging import Logger, getLogger
+from typing import List, Optional
+
+from rre_tools.dataset_generator.config import Config
+from rre_tools.shared.data_store import DataStore
+from rre_tools.shared.search_engines import BaseSearchEngine
+
+log: Logger = getLogger(__name__)
+
+
+def add_category_queries(config: Config, data_store: DataStore,
+                         search_engine: BaseSearchEngine) -> None:
+    """Render category queries from explicit values or engine value-discovery, and add them.
+
+    Explicit-values mode: ``source.values`` is a list typed by the user.
+    Engine-discovery mode: ``source.values_query_template_file`` is set instead, and the
+    engine returns the distinct values for ``source.fields[0]`` at run time.
+
+    Single warning site for empty value-discovery results — engine
+    ``fetch_field_values`` implementations return ``[]`` *silently* when the response path
+    exists but is empty so we don't log the same condition at two layers.
+
+    With a ``query_text_template_file``: each value replaces the engine-appropriate
+    placeholder (``@kw`` for Vespa, ``$query`` for Solr/Elasticsearch/OpenSearch) in the
+    template content. Without one: each value is used directly as the query text.
+    Deduplication is handled by ``DataStore.add_query``.
+    """
+    if not config.category_queries:
+        return
+    placeholder = config.category_query_placeholder
+    for source in config.category_queries:
+        # Explicit-values mode never calls the engine. The if/else is deliberate (rather
+        # than `source.values or engine.fetch_field_values(...)`): a future config knob
+        # that empties `values` mid-pipeline must not silently fall through to an engine
+        # call the user didn't ask for.
+        if source.values is not None:
+            values: List[str] = list(source.values)
+        else:
+            values = search_engine.fetch_field_values(
+                source.values_query_template_file, source.fields[0]
+            )
+
+        if not values:
+            log.warning(
+                f"[add_category_queries] no values for field='{source.fields[0]}' "
+                f"(template={source.values_query_template_file}); skipping this source"
+            )
+            continue
+
+        template: Optional[str] = (
+            source.query_text_template_file.read_text(encoding="utf-8").strip()
+            if source.query_text_template_file is not None
+            else None
+        )
+        for value in values:
+            query_text = value if template is None else template.replace(placeholder, value)
+            data_store.add_query(query_text, source="category")
+            log.debug(f"[add_category_queries] added query='{query_text}'")

--- a/rre-tools/src/rre_tools/shared/data_store.py
+++ b/rre-tools/src/rre_tools/shared/data_store.py
@@ -8,7 +8,7 @@ import logging
 from uuid import uuid4
 from pydantic import ValidationError
 from rre_tools.shared.models.document import Document
-from rre_tools.shared.models.query import Query
+from rre_tools.shared.models.query import Query, QuerySource, SOURCE_PRIORITY
 from rre_tools.shared.models.rating import Rating
 from rre_tools.shared.utils import clean_text
 
@@ -103,17 +103,47 @@ class DataStore:
         log.debug(f"[add_document] added doc_id={doc.id}")
         self._count_update_and_maybe_autosave()
 
-    def add_query(self, query_text_str: str, query_id: Optional[str] = None) -> Query:
-        """Adds a new query. If text is cached, returns existing Query. If id is given, it's used."""
+    def mark_document_as_query_seed(self, doc_id: str) -> None:
+        """Flag an already-stored document as a cartesian seed.
+
+        Required because add_document() returns early when doc_id already
+        exists, so a re-fetched doc cannot update the stored object's
+        is_used_to_generate_queries flag through that path.
+        """
+        doc = self.docs.get(doc_id)
+        if doc is None:
+            log.warning(f"[mark_document_as_query_seed] doc_not_found doc_id={doc_id}")
+            return
+        if not doc.is_used_to_generate_queries:
+            doc.is_used_to_generate_queries = True
+            self._count_update_and_maybe_autosave()
+
+    def add_query(self, query_text_str: str, query_id: Optional[str] = None,
+                  source: Optional[QuerySource] = None) -> Query:
+        """Adds a new query. If text is cached, returns existing Query. If id is given, it's used.
+
+        `source` records how the query was asserted in this run. On a dedup hit the existing
+        query is *promoted* if the incoming source has higher priority than the stored one
+        (cached < llm < user/category) — so re-asserting a previously-cached query as e.g. a
+        user-supplied query updates its label.
+        """
         key = clean_text(query_text_str) # Apply general filtering
         if existing_id := self.query_text_to_query_id.get(key):
             log.debug(f"[add_query] exists text='{query_text_str}' key='{key}' existing_id={existing_id}")
             query = self.queries[existing_id]
+            if source is not None and SOURCE_PRIORITY[source] < SOURCE_PRIORITY[query.source]:
+                log.debug(f"[add_query] promote source {query.source}->{source} for query_id={query.id}")
+                query.source = source
         else:
-            query = Query(id=query_id, text=query_text_str) if query_id else Query(text=query_text_str)
+            kwargs: Dict[str, str] = {"text": query_text_str}
+            if query_id:
+                kwargs["id"] = query_id
+            if source is not None:
+                kwargs["source"] = source
+            query = Query(**kwargs)
             self.queries[query.id] = query
             self.query_text_to_query_id[key] = query.id
-            log.debug(f"[add_query] added query_id={query.id}")
+            log.debug(f"[add_query] added query_id={query.id} source={query.source}")
             self._count_update_and_maybe_autosave()
 
         return query

--- a/rre-tools/src/rre_tools/shared/models/query.py
+++ b/rre-tools/src/rre_tools/shared/models/query.py
@@ -1,6 +1,23 @@
 from __future__ import annotations
+from typing import Dict, Literal
 from uuid import uuid4
 from pydantic import BaseModel, Field, ConfigDict
+
+# Provenance label used to prioritize which queries make it into the per-run budget.
+# It's a *runtime* label that reflects how the query was asserted in the current run, not
+# a property of the persisted data. The datastore JSON cache must not include it: anything
+# loaded from disk should be treated as 'cached' until promoted by a fresh add this run.
+QuerySource = Literal["user", "category", "llm", "cached"]
+
+# Lower number = higher priority for budgeting. user/category share priority 0 because
+# both represent explicit user intent for this run; llm-generated comes next; cached last.
+SOURCE_PRIORITY: Dict[str, int] = {
+    "user": 0,
+    "category": 0,
+    "llm": 1,
+    "cached": 2,
+}
+
 
 class Query(BaseModel):
     """
@@ -17,3 +34,6 @@ class Query(BaseModel):
 
     id: str = Field(default_factory=lambda: str(uuid4()), description="Unique identifier of the query.", min_length=1)
     text: str = Field(..., description="The raw query text.", min_length=1)
+    # Excluded from model_dump so it's never written to the datastore JSON cache;
+    # on load every query falls back to the default 'cached' label.
+    source: QuerySource = Field(default="cached", exclude=True)

--- a/rre-tools/src/rre_tools/shared/search_engines/elasticsearch_search_engine.py
+++ b/rre-tools/src/rre_tools/shared/search_engines/elasticsearch_search_engine.py
@@ -9,6 +9,9 @@ from typing import List, Dict, Any, Union, Optional
 
 from rre_tools.shared.search_engines.search_engine_base import BaseSearchEngine
 from rre_tools.shared.models.document import Document
+from rre_tools.shared.search_engines.es_opensearch_terms_agg_values import (
+    list_values_from_terms_aggregations,
+)
 from rre_tools.shared.utils import clean_text
 
 import logging
@@ -117,6 +120,30 @@ class ElasticsearchSearchEngine(BaseSearchEngine):
         fields = doc_fields if self.UNIQUE_KEY in doc_fields else doc_fields + [self.UNIQUE_KEY]
         payload["_source"] = fields
         return self._search(payload)
+
+    def fetch_field_values(self, values_query_template: Path | str, field: str) -> List[str]:
+        """Run an ES aggregation payload (full JSON request body) and return distinct values.
+
+        Convention: the aggregation result key under ``aggregations`` must equal ``field``.
+        This is about the *result key in the JSON tree*, not the aggregation's internal
+        ``terms.field`` parameter — users routinely aggregate on ``genres.keyword`` while
+        naming the agg ``genres``, which is supported.
+
+        Keyed-bucket form (``"keyed": true`` → ``buckets`` is a dict) is unsupported.
+        """
+        payload: Dict[str, Any] = self._parse_query_template(values_query_template)
+        search_url = urljoin(self.endpoint.encoded_string(), '_search')
+
+        log.debug(f"[fetch_field_values] Elasticsearch POST {search_url} payload={str(payload)[:500]}")
+
+        try:
+            response = requests.post(search_url, headers=self.HEADERS, json=payload)
+            response.raise_for_status()
+        except (ConnectionError, Timeout, RequestException, HTTPError) as e:
+            log.error(f"Elasticsearch value-discovery query failed: {e}")
+            raise
+
+        return list_values_from_terms_aggregations(response.json().get("aggregations", {}), field)
 
     def _search(self, payload: Dict[str, Any]) -> List[Document]:
         """

--- a/rre-tools/src/rre_tools/shared/search_engines/es_opensearch_terms_agg_values.py
+++ b/rre-tools/src/rre_tools/shared/search_engines/es_opensearch_terms_agg_values.py
@@ -1,0 +1,33 @@
+"""Parse Elasticsearch/OpenSearch `_search` terms-aggregation responses for value discovery."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from rre_tools.shared.utils import normalize_discovered_field_values
+
+
+def list_values_from_terms_aggregations(aggregations: Any, field: str) -> List[str]:
+    """Return normalized distinct values from ``aggregations[field].buckets[*].key``.
+
+    Convention: the aggregation result key under the response's ``aggregations`` object must
+    equal ``field`` (the request body still uses ``aggs``). Keyed-bucket form
+    (``\"keyed\": true``) is unsupported.
+    """
+    if not isinstance(aggregations, dict):
+        aggregations = {}
+    agg_entry = aggregations.get(field)
+    if not isinstance(agg_entry, dict) or "buckets" not in agg_entry:
+        raise ValueError(
+            f"ES/OS value-discovery: expected aggregations.{field}.buckets in response. "
+            f"Convention: the aggregation result key must equal fields[0] ('{field}'); "
+            f"the aggregation's internal terms.field can be a keyword subfield "
+            f"(e.g. '{field}.keyword') without affecting this convention."
+        )
+    buckets = agg_entry["buckets"]
+    if not isinstance(buckets, list):
+        raise ValueError(
+            f"ES/OS value-discovery: aggregations.{field}.buckets must be a list. "
+            f"Keyed-bucket aggregations (`'keyed': true`) are not supported."
+        )
+    return normalize_discovered_field_values(b.get("key") for b in buckets)

--- a/rre-tools/src/rre_tools/shared/search_engines/opensearch_engine.py
+++ b/rre-tools/src/rre_tools/shared/search_engines/opensearch_engine.py
@@ -9,6 +9,9 @@ from requests.exceptions import HTTPError, ConnectionError, Timeout, RequestExce
 
 from rre_tools.shared.models.document import Document
 from rre_tools.shared.search_engines.search_engine_base import BaseSearchEngine
+from rre_tools.shared.search_engines.es_opensearch_terms_agg_values import (
+    list_values_from_terms_aggregations,
+)
 from rre_tools.shared.utils import clean_text
 
 log = logging.getLogger(__name__)
@@ -95,6 +98,28 @@ class OpenSearchEngine(BaseSearchEngine):
         payload["_source"] = fields
 
         return self._search(payload)
+
+    def fetch_field_values(self, values_query_template: Path | str, field: str) -> List[str]:
+        """Run an OpenSearch aggregation payload (full JSON request body) and return distinct values.
+
+        Convention mirrors Elasticsearch: the aggregation result key under ``aggregations`` must
+        equal ``field`` (the agg's internal ``terms.field`` may be a keyword subfield).
+
+        Keyed-bucket form (``"keyed": true`` → ``buckets`` is a dict) is unsupported.
+        """
+        payload: Dict[str, Any] = self._parse_query_template(values_query_template)
+        search_url = f"{self.endpoint}/_search"
+
+        log.debug(f"[fetch_field_values] OpenSearch POST {search_url} payload={str(payload)[:500]}")
+
+        try:
+            response = requests.post(search_url, headers=self.HEADERS, json=payload)
+            response.raise_for_status()
+        except (ConnectionError, Timeout, RequestException, HTTPError) as e:
+            log.error(f"OpenSearch value-discovery query failed: {e}")
+            raise
+
+        return list_values_from_terms_aggregations(response.json().get("aggregations", {}), field)
 
     def _search(self, payload: Dict[str, Any]) -> List[Document]:
         """Perform a search to OpenSearch and return matching documents based on the given payload."""

--- a/rre-tools/src/rre_tools/shared/search_engines/search_engine_base.py
+++ b/rre-tools/src/rre_tools/shared/search_engines/search_engine_base.py
@@ -13,9 +13,12 @@ class BaseSearchEngine(ABC):
     SPECIAL_CHARS: set[str] = {'\\', '+', '-', '!', '(', ')', ':', '^', '[', ']', '"',
                                '{', '}', '~', '*', '?', '|', '&', '/'}
 
+    # Engine-specific placeholder convention used in query templates. Subclasses override
+    # when their engine uses a different convention (e.g. Vespa uses YQL '@kw').
+    QUERY_PLACEHOLDER: str = "$query"
+
     def __init__(self, endpoint: HttpUrl):
         self.endpoint = HttpUrl(endpoint)
-        self.QUERY_PLACEHOLDER = "$query"
         self.UNIQUE_KEY = 'id'
 
     @staticmethod
@@ -100,6 +103,38 @@ class BaseSearchEngine(ABC):
                              keyword: str="*:*") \
             -> List[Document]:
         """Search for documents based on a keyword and a query template to evaluate the system."""
+        pass
+
+    @abstractmethod
+    def fetch_field_values(self, values_query_template: Path | str, field: str) -> List[str]:
+        """Run an engine-native facet/aggregation/grouping payload and return the distinct values
+        produced for ``field``.
+
+        Per-engine transport (deliberately different so each engine matches its existing
+        retrieval convention):
+
+        - **Solr** — the template is a JSON dict of Solr request *parameters* (``q``, ``facet``,
+          ``facet.field``, ``facet.limit``, ``rows``, ...). Parsed with ``_parse_query_template``,
+          ``wt=json`` is injected, and the call is ``GET /select?<params>`` (NOT a Solr JSON
+          Request API body).
+        - **Elasticsearch / OpenSearch** — the template is the full JSON request body, POSTed
+          to ``_search`` unchanged.
+        - **Vespa** — the template is YQL only; the implementation wraps it with
+          ``{"yql": <file>, "hits": 0, "presentation.format": "json"}`` and POSTs.
+
+        The template's limit (Solr ``facet.limit``, ES/OS terms ``size``, Vespa grouping
+        ``max(N)``) is the only knob — there is no separate config option.
+
+        Return values are normalized to non-empty stripped strings via
+        ``shared.utils.normalize_discovered_field_values`` (containers raise).
+
+        Empty result (response path exists but contains zero buckets/values) → return ``[]``
+        *silently*. The single warning lives in ``add_category_queries`` so it carries full
+        source context (``field``, ``values_query_template_file``).
+
+        Missing/wrong-typed/wrong-key response path → raise ``ValueError`` with engine context.
+        HTTP/JSON parse errors propagate or are wrapped with engine context.
+        """
         pass
 
     @abstractmethod

--- a/rre-tools/src/rre_tools/shared/search_engines/search_engine_factory.py
+++ b/rre-tools/src/rre_tools/shared/search_engines/search_engine_factory.py
@@ -5,6 +5,7 @@ from rre_tools.shared.search_engines.opensearch_engine import OpenSearchEngine
 from rre_tools.shared.search_engines.search_engine_base import BaseSearchEngine
 from rre_tools.shared.search_engines.solr_search_engine import SolrSearchEngine
 from rre_tools.shared.search_engines.elasticsearch_search_engine import ElasticsearchSearchEngine
+from rre_tools.shared.search_engines.vespa_search_engine import VespaSearchEngine
 
 import logging
 
@@ -15,7 +16,8 @@ class SearchEngineFactory:
     SEARCH_ENGINE_REGISTRY: Dict[str, Type[BaseSearchEngine]] = {
         "solr": SolrSearchEngine,
         "opensearch": OpenSearchEngine,
-        "elasticsearch": ElasticsearchSearchEngine
+        "elasticsearch": ElasticsearchSearchEngine,
+        "vespa": VespaSearchEngine,
     }
 
     @classmethod

--- a/rre-tools/src/rre_tools/shared/search_engines/solr_search_engine.py
+++ b/rre-tools/src/rre_tools/shared/search_engines/solr_search_engine.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Any, Union
 
 from rre_tools.shared.search_engines.search_engine_base import BaseSearchEngine
 from rre_tools.shared.models.document import Document
-from rre_tools.shared.utils import clean_text
+from rre_tools.shared.utils import clean_text, normalize_discovered_field_values
 
 import logging
 import json
@@ -114,6 +114,46 @@ class SolrSearchEngine(BaseSearchEngine):
         payload['fl'] = self._unify_fields(doc_fields)
 
         return self._search(payload)
+
+    def fetch_field_values(self, values_query_template: Path | str, field: str) -> List[str]:
+        """Run a Solr facet payload (request-params dict) and return distinct values for ``field``.
+
+        The template is a flat JSON dict of Solr request parameters. ``wt=json`` is injected
+        the same way ``_search`` does, and the request goes out as ``GET /select?<params>``.
+        Response navigation: ``facet_counts.facet_fields.<field>`` is a flat alternating
+        ``[v0, c0, v1, c1, ...]`` array; we drop counts and keep the values.
+        """
+        payload: Dict[str, Any] = self._parse_query_template(values_query_template)
+        payload['wt'] = 'json'
+        search_url = urljoin(self.endpoint.encoded_string(), 'select')
+
+        log.debug(f"[fetch_field_values] Solr GET {search_url} params={str(payload)[:500]}")
+
+        try:
+            response = requests.get(search_url, headers=self.HEADERS, params=payload)
+            response.raise_for_status()
+        except (ConnectionError, Timeout, RequestException, HTTPError) as e:
+            log.error(f"Solr value-discovery query failed: {e}")
+            raise
+
+        body = response.json()
+        fc = body.get("facet_counts")
+        if fc is None or "facet_fields" not in fc or field not in fc["facet_fields"]:
+            raise ValueError(
+                f"Solr value-discovery: expected facet_counts.facet_fields.{field} in response."
+            )
+        arr = fc["facet_fields"][field]
+        if not isinstance(arr, list):
+            raise ValueError(
+                f"Solr value-discovery: facet_counts.facet_fields.{field} must be a list, "
+                f"got {type(arr).__name__}."
+            )
+        if len(arr) % 2 != 0:
+            raise ValueError(
+                f"Solr value-discovery: facet_counts.facet_fields.{field} must have even length "
+                f"(alternating value/count), got len={len(arr)}."
+            )
+        return normalize_discovered_field_values(arr[i] for i in range(0, len(arr), 2))
 
     def _search(self, payload: Dict[str, Any]) -> List[Document]:
         """

--- a/rre-tools/src/rre_tools/shared/search_engines/vespa_search_engine.py
+++ b/rre-tools/src/rre_tools/shared/search_engines/vespa_search_engine.py
@@ -10,7 +10,7 @@ from pydantic import HttpUrl
 
 from rre_tools.shared.search_engines.search_engine_base import BaseSearchEngine
 from rre_tools.shared.models.document import Document
-from rre_tools.shared.utils import clean_text
+from rre_tools.shared.utils import clean_text, normalize_discovered_field_values
 
 
 log = logging.getLogger(__name__)
@@ -27,6 +27,11 @@ class VespaSearchEngine(BaseSearchEngine):
     Thin HTTP wrapper around the Vespa Query API.
     Assumes an already deployed a schema called `doc`.
     """
+
+    # Vespa YQL uses parameter-binding syntax (e.g. `userInput(@kw)`) rather than the
+    # `$query` string-replace convention used by Solr / Elasticsearch / OpenSearch.
+    QUERY_PLACEHOLDER: str = "@kw"
+
     def __init__(self, endpoint: HttpUrl):
         super().__init__(endpoint)
         # Extract schema from endpoint path: http://host:port/schema_name/
@@ -70,7 +75,16 @@ class VespaSearchEngine(BaseSearchEngine):
         return int(response.json().get("root", {}).get("fields", {}).get("totalCount", 0))
 
     def _build_yql(self, select_fields: List[str], where_clause: str = "true") -> str:
-        fields = ", ".join(select_fields) if select_fields else "*"
+        # Always project Vespa's built-in `documentid` summary field so `_search` can
+        # surface the user document id (`id:ns:type::user`) instead of the internal GID
+        # (`index:schema/0/<hash>`) that `hit["id"]` falls back to under restricted projections.
+        if select_fields:
+            projected = list(select_fields)
+            if "documentid" not in projected:
+                projected.insert(0, "documentid")
+            fields = ", ".join(projected)
+        else:
+            fields = "*"
         return f"select {fields} from {self.schema} where {where_clause}"
 
     @staticmethod
@@ -204,6 +218,80 @@ class VespaSearchEngine(BaseSearchEngine):
         return self._search(payload)
 
 
+    def fetch_field_values(self, values_query_template: Path | str, field: str) -> List[str]:
+        """Run a Vespa grouping query and return distinct values for ``field``.
+
+        The template contains YQL only — the engine wraps it with ``hits=0`` and
+        ``presentation.format=json`` automatically (YQL itself can't express those).
+        Vespa grouping requires the grouped field to be an ``attribute`` in the .sd schema;
+        a non-attribute field will fail at Vespa, not here.
+
+        Response shape (nested under ``group:root:0``):
+            root.children[]
+               group:root:0
+                   children[]
+                       grouplist:<field>
+                           children[]
+                               group:string:<value>
+                                   value: "<value>"
+        We do a recursive walk for any node whose ``id == 'grouplist:<field>'`` or
+        ``label == field`` and return each child's ``value``.
+        """
+        path = Path(values_query_template)
+        yql = path.read_text(encoding="utf-8").strip()
+
+        payload: Dict[str, Any] = {
+            "yql": yql,
+            "hits": 0,
+            "presentation.format": "json",
+        }
+
+        base = str(self.endpoint).rstrip("/")
+        search_url = f"{base}/search/"
+
+        log.debug(f"[fetch_field_values] Vespa POST {search_url} payload={str(payload)[:500]}")
+
+        try:
+            response = requests.post(
+                search_url,
+                headers=self.HEADERS,
+                json=payload,
+                timeout=DEFAULT_TIMEOUT,
+                allow_redirects=False,
+            )
+            response.raise_for_status()
+        except (ConnectionError, Timeout, RequestException) as e:
+            log.error(f"Vespa value-discovery query to {search_url} failed: {e}")
+            raise
+
+        body = response.json()
+        seen: List[str] = []
+        grouplist = self._find_grouplist(body.get("root", {}), field, seen)
+        if grouplist is None:
+            raise ValueError(
+                f"Vespa value-discovery: no grouplist found for field '{field}'. "
+                f"Encountered nodes: {[s for s in seen if s]}. "
+                f"Note: Vespa grouping requires the grouped field to be an attribute in the schema."
+            )
+        return normalize_discovered_field_values(
+            b.get("value") for b in (grouplist.get("children") or [])
+        )
+
+    @staticmethod
+    def _find_grouplist(node: Any, field: str, seen: List[str]) -> Optional[Dict[str, Any]]:
+        if isinstance(node, dict):
+            if str(node.get("id", "")) == f"grouplist:{field}" or node.get("label") == field:
+                return node
+            label = node.get("id") or node.get("label")
+            if label is not None:
+                seen.append(str(label))
+            for child in node.get("children", []) or []:
+                found = VespaSearchEngine._find_grouplist(child, field, seen)
+                if found is not None:
+                    return found
+        return None
+
+
     # ---- low‑level call --------------------------------------------------
 
     def _search(self, payload: Dict[str, Any]) -> List[Document]:
@@ -240,11 +328,14 @@ class VespaSearchEngine(BaseSearchEngine):
         hits = (raw_response.get("root") or {}).get("children") or []
         docs: List[Document] = []
         for hit in hits:
-            doc_id = hit.get("id")
+            fields = hit.get("fields", {}) or {}
+            # Prefer the user document id from `fields.documentid` (always projected by `_build_yql`).
+            # Fall back to `hit["id"]` so callers that bypass `_build_yql` (or hit a Vespa version
+            # that omits the summary field) still get something usable, even if it's the GID form.
+            doc_id = fields.get("documentid") or hit.get("id")
             if not doc_id:
                 log.debug(f"Potential corrupted entry without id in Vespa _search: {hit}")
                 continue
-            fields = hit.get("fields", {}) or {}
 
             normalized_fields = {k: self._normalize_field_value(v) for k, v in fields.items()}
             docs.append(Document(id=doc_id, fields=normalized_fields))

--- a/rre-tools/src/rre_tools/shared/utils.py
+++ b/rre-tools/src/rre_tools/shared/utils.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Iterable, List
 import re
 import html
 import unicodedata
@@ -52,6 +52,45 @@ def clean_text(text: str) -> str:
     # Normalize whitespace
     t = _WS_REGEX.sub(" ", t).strip()
     return t
+
+def normalize_discovered_field_values(values: Iterable[Any]) -> List[str]:
+    """Normalize bucket keys returned by an engine's value-discovery query.
+
+    Used by `BaseSearchEngine.fetch_field_values` implementations to turn raw bucket keys
+    (Solr facet values, ES/OS aggregation `bucket.key`, Vespa grouping `bucket.value`) into
+    `List[str]` that downstream string substitution can safely consume.
+
+    This is intentionally separate from the per-engine `Document.fields` normalizers
+    (`SolrSearchEngine._normalize`, `VespaSearchEngine._normalize_field_value`, etc.):
+    those preserve containers as JSON; this rejects them so a misconfigured aggregation that
+    produces nested buckets surfaces as a `ValueError` rather than landing
+    `"{'key': 'comedy'}"` as a query.
+
+    Steps (in order):
+      1. Drop None.
+      2. Accept only str/int/float/bool. Raise ValueError on list/dict/other containers.
+      3. str(value) on accepted scalars.
+      4. Strip surrounding whitespace.
+      5. Drop empty strings after stripping.
+      6. Preserve input order. No sorting, no deduping (DataStore.add_query handles dedupe
+         via clean_text on the rendered query text).
+    """
+    out: List[str] = []
+    for v in values:
+        if v is None:
+            continue
+        if isinstance(v, bool) or isinstance(v, (int, float, str)):
+            stripped = str(v).strip()
+            if stripped:
+                out.append(stripped)
+            continue
+        raise ValueError(
+            f"normalize_discovered_field_values: unsupported bucket value type {type(v).__name__} "
+            f"({v!r}). Only scalars (str, int, float, bool) are supported; nested containers "
+            f"indicate a compound aggregation, which is not supported."
+        )
+    return out
+
 
 def join_fields_as_text(fields: dict[str, Any], exclude: set[str] | str) -> str:
     if isinstance(exclude, str):

--- a/rre-tools/templates/genre_facet_es.json
+++ b/rre-tools/templates/genre_facet_es.json
@@ -1,0 +1,8 @@
+{
+  "size": 0,
+  "aggs": {
+    "genres": {
+      "terms": { "field": "genres.keyword", "size": 100 }
+    }
+  }
+}

--- a/rre-tools/templates/genre_facet_opensearch.json
+++ b/rre-tools/templates/genre_facet_opensearch.json
@@ -1,0 +1,8 @@
+{
+  "size": 0,
+  "aggs": {
+    "genres": {
+      "terms": { "field": "genres.keyword", "size": 100 }
+    }
+  }
+}

--- a/rre-tools/templates/genre_facet_solr.json
+++ b/rre-tools/templates/genre_facet_solr.json
@@ -1,0 +1,7 @@
+{
+  "q": "*:*",
+  "facet": "true",
+  "facet.field": "genres",
+  "facet.limit": 100,
+  "rows": 0
+}

--- a/rre-tools/templates/genre_facet_vespa.yql
+++ b/rre-tools/templates/genre_facet_vespa.yql
@@ -1,0 +1,1 @@
+select * from sources * where true LIMIT 0 | all(group(genres) max(100) each(output(count())))

--- a/rre-tools/templates/genre_query.tmpl
+++ b/rre-tools/templates/genre_query.tmpl
@@ -1,0 +1,1 @@
+$query movies

--- a/rre-tools/tests/__init__.py
+++ b/rre-tools/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package marker so ``tests.*`` imports resolve (e.g. shared test helpers)."""

--- a/rre-tools/tests/dataset_generator/__init__.py
+++ b/rre-tools/tests/dataset_generator/__init__.py
@@ -1,0 +1,1 @@
+"""Dataset-generator test subpackage."""

--- a/rre-tools/tests/dataset_generator/category_query_test_utils.py
+++ b/rre-tools/tests/dataset_generator/category_query_test_utils.py
@@ -1,0 +1,135 @@
+"""Shared helpers for category-query and main() wiring tests (not collected by pytest)."""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List
+
+from rre_tools.dataset_generator import main as main_mod
+from rre_tools.dataset_generator.config import Config
+from rre_tools.shared.models import Document
+
+
+def llm_cfg(tmp_path: Path) -> Path:
+    p = tmp_path / "llm_cfg.yaml"
+    p.write_text("name: mock\nmodel: mock-model\nmax_tokens: 16\n", encoding="utf-8")
+    return p
+
+
+def genre_query_template(tmp_path: Path) -> Path:
+    p = tmp_path / "genre_query.tmpl"
+    p.write_text("$query movies\n", encoding="utf-8")
+    return p
+
+
+def make_config(tmp_path: Path, **overrides) -> Config:
+    base = dict(
+        query_template=None,
+        search_engine_type="solr",
+        collection_name="testcore",
+        search_engine_url="http://localhost:8983/solr/",
+        documents_filter=None,
+        number_of_docs=2,
+        doc_fields=["title", "genres"],
+        queries=None,
+        generate_queries_from_documents=True,
+        num_queries_needed=10,
+        relevance_scale="graded",
+        llm_configuration_file=llm_cfg(tmp_path),
+        output_format="quepid",
+        output_destination=tmp_path,
+        save_llm_explanation=False,
+        llm_explanation_destination=None,
+        id_field=None,
+        rre_query_template=None,
+        rre_query_placeholder=None,
+        verbose=False,
+        datastore_autosave_every_n_updates=None,
+        enable_cartesian_product=True,
+    )
+    base.update(overrides)
+    return Config(**base)
+
+
+class FakeSearchEngine:
+    def __init__(self, docs: List[Document]):
+        self._docs = docs
+        self.fetch_calls = 0
+
+    def fetch_for_query_generation(self, documents_filter, number_of_docs, doc_fields):
+        self.fetch_calls += 1
+        return list(self._docs)
+
+    def fetch_field_values(self, values_query_template, field):
+        raise AssertionError(
+            "fetch_field_values should not be called for explicit-values configs"
+        )
+
+
+class FakeLLMService:
+    def __init__(self, queries_per_doc=None, score=2):
+        self._queries_per_doc = queries_per_doc or {}
+        self._score = score
+        self.generate_queries_calls = []
+        self.generate_score_calls = []
+
+    def generate_queries(self, doc, num_queries_per_doc, max_query_terms):
+        self.generate_queries_calls.append(doc.id)
+        queries = self._queries_per_doc.get(doc.id, [f"q-from-{doc.id}"])
+        return SimpleNamespace(get_queries=lambda: queries)
+
+    def generate_score(self, document, query, relevance_scale, explanation=False):
+        self.generate_score_calls.append((document.id, query))
+        score = self._score
+        return SimpleNamespace(score=score, explanation=None, get_score=lambda: score)
+
+
+class DummyWriter:
+    def write(self, output_destination, data_store):
+        return None
+
+
+def patch_main_dependencies(monkeypatch, cfg, search_engine, llm_service, *,
+                             stub_cartesian: bool = True):
+    monkeypatch.setattr(main_mod, "Config", types.SimpleNamespace(load=lambda _path: cfg))
+    monkeypatch.setattr(
+        main_mod, "parse_args",
+        lambda: types.SimpleNamespace(config="ignored.yaml", verbose=False),
+    )
+    monkeypatch.setattr(
+        main_mod, "SearchEngineFactory",
+        types.SimpleNamespace(build=lambda **kwargs: search_engine),
+    )
+    monkeypatch.setattr(main_mod, "LLMConfig", types.SimpleNamespace(load=lambda _path: object()))
+    monkeypatch.setattr(
+        main_mod, "LLMServiceFactory",
+        types.SimpleNamespace(build=lambda _cfg: object()),
+    )
+    monkeypatch.setattr(main_mod, "LLMService", lambda chat_model: llm_service)
+    monkeypatch.setattr(
+        main_mod, "WriterFactory",
+        types.SimpleNamespace(build=lambda _cfg: DummyWriter()),
+    )
+    if stub_cartesian:
+        monkeypatch.setattr(main_mod, "add_cartesian_product_scores", lambda *a, **kw: None)
+    monkeypatch.setattr(main_mod, "expand_docset_with_search_engine_top_k", lambda *a, **kw: None)
+
+
+class ValueDiscoveryEngine:
+    """Engine fake exposing only `fetch_field_values` (value-discovery path)."""
+
+    def __init__(self, values_by_field=None):
+        self._values_by_field = values_by_field or {}
+        self.calls = []
+
+    def fetch_field_values(self, values_query_template, field):
+        self.calls.append((values_query_template, field))
+        return list(self._values_by_field.get(field, []))
+
+
+def empty_solr_facet_template(tmp_path: Path) -> Path:
+    p = tmp_path / "facet_solr.json"
+    p.write_text('{"q": "*:*", "facet": "true", "facet.field": "genres", "rows": 0}\n', encoding="utf-8")
+    return p

--- a/rre-tools/tests/dataset_generator/conftest.py
+++ b/rre-tools/tests/dataset_generator/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from pathlib import Path
 
+
 @pytest.fixture
 def resource_folder():
     return Path(__file__).parent.parent / "resources"

--- a/rre-tools/tests/dataset_generator/test_add_category_queries.py
+++ b/rre-tools/tests/dataset_generator/test_add_category_queries.py
@@ -1,0 +1,150 @@
+from pathlib import Path
+
+from rre_tools.dataset_generator.query_sources import add_category_queries
+from rre_tools.shared.data_store import DataStore
+
+from tests.dataset_generator.category_query_test_utils import (
+    FakeSearchEngine,
+    ValueDiscoveryEngine,
+    empty_solr_facet_template,
+    genre_query_template,
+    make_config,
+)
+
+
+def test_add_category_queries__renders_and_dedupes(tmp_path):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy", "action", "comedy"],
+             "query_text_template_file": str(template)},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([])
+
+    add_category_queries(cfg, ds, engine)
+
+    texts = sorted(q.text for q in ds.get_queries())
+    assert texts == ["action movies", "comedy movies"]
+
+
+def test_add_category_queries__none_is_noop(tmp_path):
+    cfg = make_config(tmp_path, category_queries=None)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([])
+    add_category_queries(cfg, ds, engine)
+    assert ds.get_queries() == []
+
+
+def test_add_category_queries__bare_values_when_template_omitted(tmp_path):
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy", "action"]},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([])
+
+    add_category_queries(cfg, ds, engine)
+
+    texts = sorted(q.text for q in ds.get_queries())
+    assert texts == ["action", "comedy"]
+    assert all(q.source == "category" for q in ds.get_queries())
+
+
+def test_add_category_queries__engine_discovery_calls_fetch_field_values_once_per_source(tmp_path):
+    facet = empty_solr_facet_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values_query_template_file": str(facet)},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = ValueDiscoveryEngine(values_by_field={"genres": ["comedy", "action"]})
+
+    add_category_queries(cfg, ds, engine)
+
+    assert len(engine.calls) == 1
+    template_arg, field_arg = engine.calls[0]
+    assert Path(template_arg) == facet
+    assert field_arg == "genres"
+    texts = sorted(q.text for q in ds.get_queries())
+    assert texts == ["action", "comedy"]
+    assert all(q.source == "category" for q in ds.get_queries())
+
+
+def test_add_category_queries__engine_discovery_renders_through_query_text_template(tmp_path):
+    facet = empty_solr_facet_template(tmp_path)
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values_query_template_file": str(facet),
+             "query_text_template_file": str(template)},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = ValueDiscoveryEngine(values_by_field={"genres": ["comedy", "action"]})
+
+    add_category_queries(cfg, ds, engine)
+
+    assert sorted(q.text for q in ds.get_queries()) == ["action movies", "comedy movies"]
+
+
+def test_add_category_queries__engine_discovery_empty_result_warns_and_skips_source(tmp_path, caplog):
+    facet = empty_solr_facet_template(tmp_path)
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values_query_template_file": str(facet)},
+            {"fields": ["genres"], "values": ["fallback"],
+             "query_text_template_file": str(template)},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = ValueDiscoveryEngine(values_by_field={"genres": []})
+
+    with caplog.at_level("WARNING"):
+        add_category_queries(cfg, ds, engine)
+
+    warnings = [r for r in caplog.records if "no values" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "field='genres'" in warnings[0].getMessage()
+    assert any(q.text == "fallback movies" for q in ds.get_queries())
+
+
+def test_add_category_queries__explicit_values_short_circuit_does_not_call_engine(tmp_path):
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy"]},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([])
+
+    add_category_queries(cfg, ds, engine)
+
+    assert [q.text for q in ds.get_queries()] == ["comedy"]
+
+
+def test_add_category_queries__rendered_duplicates_dedupe(tmp_path):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy", "comedy "],
+             "query_text_template_file": str(template)},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([])
+
+    add_category_queries(cfg, ds, engine)
+
+    assert len(ds.get_queries()) == 1

--- a/rre-tools/tests/dataset_generator/test_config_category_queries.py
+++ b/rre-tools/tests/dataset_generator/test_config_category_queries.py
@@ -1,0 +1,389 @@
+from pathlib import Path
+
+import pytest
+from pydantic_core import ValidationError
+
+from rre_tools.dataset_generator.config import Config
+
+
+def _base_cfg_kwargs(tmp_path: Path) -> dict:
+    """Minimal kwargs for a valid Config; tests override what they need."""
+    llm_cfg = tmp_path / "llm_cfg.yaml"
+    llm_cfg.write_text("name: mock\nmodel: mock-model\nmax_tokens: 16\n", encoding="utf-8")
+    return dict(
+        query_template=None,
+        search_engine_type="solr",
+        collection_name="testcore",
+        search_engine_url="http://localhost:8983/solr/",
+        documents_filter=None,
+        number_of_docs=1,
+        doc_fields=["title", "genres"],
+        queries=None,
+        generate_queries_from_documents=True,
+        num_queries_needed=1,
+        relevance_scale="graded",
+        llm_configuration_file=llm_cfg,
+        output_format="quepid",
+        output_destination=tmp_path,
+        save_llm_explanation=False,
+        llm_explanation_destination=None,
+        id_field=None,
+        rre_query_template=None,
+        rre_query_placeholder=None,
+        verbose=False,
+        datastore_autosave_every_n_updates=None,
+        enable_cartesian_product=False,
+    )
+
+
+def _write_template(tmp_path: Path, content: str = "$query movies\n") -> Path:
+    template = tmp_path / "genre_query.tmpl"
+    template.write_text(content, encoding="utf-8")
+    return template
+
+
+def test_category_queries__valid_config_renders_expected_query_strings(tmp_path):
+    template = _write_template(tmp_path)
+    cfg = Config(
+        **_base_cfg_kwargs(tmp_path),
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy", "action"], "query_text_template_file": str(template)},
+        ],
+    )
+
+    source = cfg.category_queries[0]
+    raw = source.query_text_template_file.read_text(encoding="utf-8").strip()
+    rendered = [raw.replace(cfg.category_query_placeholder, v) for v in source.values]
+    assert rendered == ["comedy movies", "action movies"]
+
+
+def test_category_queries__vespa_uses_at_kw_placeholder(tmp_path):
+    template = _write_template(tmp_path, content="@kw movies\n")
+    base = _base_cfg_kwargs(tmp_path)
+    base["search_engine_type"] = "vespa"
+    base["search_engine_url"] = "http://localhost:8080/search/"
+    base["query_template"] = None
+    cfg = Config(
+        **base,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+        ],
+    )
+    assert cfg.category_query_placeholder == "@kw"
+
+
+def test_category_queries__vespa_template_with_dollar_query_fails_validation(tmp_path):
+    """Sanity: a Vespa-engine config rejects a template that uses $query (Solr convention)."""
+    template = _write_template(tmp_path, content="$query movies\n")
+    base = _base_cfg_kwargs(tmp_path)
+    base["search_engine_type"] = "vespa"
+    base["search_engine_url"] = "http://localhost:8080/search/"
+    base["query_template"] = None
+    with pytest.raises(ValidationError, match="@kw"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+            ],
+        )
+
+
+def test_category_queries__missing_template_file_fails_validation(tmp_path):
+    with pytest.raises(ValidationError):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(tmp_path / "nope.tmpl")},
+            ],
+        )
+
+
+def test_category_queries__template_without_placeholder_fails_validation(tmp_path):
+    template = _write_template(tmp_path, content="just movies\n")
+    with pytest.raises(ValidationError):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+            ],
+        )
+
+
+def test_category_queries__empty_string_in_fields_fails_validation(tmp_path):
+    template = _write_template(tmp_path)
+    with pytest.raises(ValidationError):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": [" "], "values": ["comedy"], "query_text_template_file": str(template)},
+            ],
+        )
+
+
+def test_category_queries__empty_string_in_values_fails_validation(tmp_path):
+    template = _write_template(tmp_path)
+    with pytest.raises(ValidationError):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values": [""], "query_text_template_file": str(template)},
+            ],
+        )
+
+
+def test_category_queries__multiple_fields_rejected(tmp_path):
+    template = _write_template(tmp_path)
+    with pytest.raises(ValidationError, match="not yet supported"):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {
+                    "fields": ["genres", "sub_genres"],
+                    "values": ["comedy"],
+                    "query_text_template_file": str(template),
+                },
+            ],
+        )
+
+
+def test_category_queries__field_not_in_doc_fields_fails_validation(tmp_path):
+    template = _write_template(tmp_path)
+    base = _base_cfg_kwargs(tmp_path)
+    base["doc_fields"] = ["title"]  # 'genres' is missing
+    with pytest.raises(ValidationError, match="doc_fields"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+            ],
+        )
+
+
+def test_category_queries__omitted_defaults_to_none(tmp_path):
+    cfg = Config(**_base_cfg_kwargs(tmp_path))
+    assert cfg.category_queries is None
+
+
+def test_category_queries__template_omitted_uses_bare_values(tmp_path):
+    """`query_text_template_file` is optional; without it, each value is the query text directly."""
+    cfg = Config(
+        **_base_cfg_kwargs(tmp_path),
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy", "action"]},
+        ],
+    )
+    assert cfg.category_queries[0].query_text_template_file is None
+
+
+def test_category_queries__same_path_as_query_template_fails_validation(tmp_path):
+    """Pointing query_text_template_file at the engine retrieval template (e.g. a YQL or Solr
+    JSON file) is the most common misuse — substitution would dump the engine payload as the
+    query string. Reject it explicitly with a clear error."""
+    shared = tmp_path / "query_template.yql"
+    shared.write_text("select * from movie where userInput($query) LIMIT 2\n", encoding="utf-8")
+    base = _base_cfg_kwargs(tmp_path)
+    base["query_template"] = str(shared)
+    with pytest.raises(ValidationError, match="same file as the engine retrieval"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(shared)},
+            ],
+        )
+
+
+def test_category_queries__same_path_as_rre_query_template_fails_validation(tmp_path):
+    shared = tmp_path / "rre_query.json"
+    shared.write_text('{"q": "$query"}\n', encoding="utf-8")
+    base = _base_cfg_kwargs(tmp_path)
+    base["query_template"] = None
+    base["rre_query_template"] = str(shared)
+    with pytest.raises(ValidationError, match="same file as the engine retrieval"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(shared)},
+            ],
+        )
+
+
+def test_generate_queries_from_documents__omitted_defaults_to_true(tmp_path):
+    base = _base_cfg_kwargs(tmp_path)
+    base.pop("generate_queries_from_documents")
+    cfg = Config(**base)
+    assert cfg.generate_queries_from_documents is True
+
+
+def test_generate_queries_from_documents__explicit_false_is_respected(tmp_path):
+    base = _base_cfg_kwargs(tmp_path)
+    base["generate_queries_from_documents"] = False
+    cfg = Config(**base)
+    assert cfg.generate_queries_from_documents is False
+
+
+def _write_solr_facet_template(tmp_path: Path) -> Path:
+    p = tmp_path / "genre_facet_solr.json"
+    p.write_text(
+        '{"q": "*:*", "facet": "true", "facet.field": "genres", "facet.limit": 100, "rows": 0}\n',
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_category_queries__values_and_values_query_template_file_both_set_fails(tmp_path):
+    facet = _write_solr_facet_template(tmp_path)
+    with pytest.raises(ValidationError, match="exactly one"):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "values_query_template_file": str(facet)},
+            ],
+        )
+
+
+def test_category_queries__neither_values_nor_values_query_template_file_fails(tmp_path):
+    with pytest.raises(ValidationError, match="exactly one"):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"]},
+            ],
+        )
+
+
+def test_category_queries__values_null_with_values_query_template_file_passes(tmp_path):
+    facet = _write_solr_facet_template(tmp_path)
+    cfg = Config(
+        **_base_cfg_kwargs(tmp_path),
+        category_queries=[
+            {"fields": ["genres"], "values": None, "values_query_template_file": str(facet)},
+        ],
+    )
+    assert cfg.category_queries[0].values is None
+    assert cfg.category_queries[0].values_query_template_file is not None
+
+
+def test_category_queries__values_null_and_values_query_template_file_null_fails(tmp_path):
+    with pytest.raises(ValidationError, match="exactly one"):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values": None, "values_query_template_file": None},
+            ],
+        )
+
+
+def test_category_queries__values_query_template_file_at_query_template_path_fails(tmp_path):
+    """values_query_template_file pointing at top-level query_template (engine retrieval payload)."""
+    shared = tmp_path / "query_template.json"
+    shared.write_text('{"q": "$query"}\n', encoding="utf-8")
+    base = _base_cfg_kwargs(tmp_path)
+    base["query_template"] = str(shared)
+    with pytest.raises(ValidationError, match="value-discovery"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values_query_template_file": str(shared)},
+            ],
+        )
+
+
+def test_category_queries__values_query_template_file_at_rre_query_template_path_fails(tmp_path):
+    shared = tmp_path / "rre_query.json"
+    shared.write_text('{"q": "$query"}\n', encoding="utf-8")
+    base = _base_cfg_kwargs(tmp_path)
+    base["query_template"] = None
+    base["rre_query_template"] = str(shared)
+    with pytest.raises(ValidationError, match="value-discovery"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values_query_template_file": str(shared)},
+            ],
+        )
+
+
+def test_category_queries__values_query_template_file_same_as_query_text_template_file_fails(tmp_path):
+    """Three-way collision check: values_query_template_file must not equal
+    query_text_template_file on the same source."""
+    shared = tmp_path / "shared.json"
+    shared.write_text('{"q": "*:*"}\n', encoding="utf-8")
+    with pytest.raises(ValidationError, match="different concepts"):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {
+                    "fields": ["genres"],
+                    "values_query_template_file": str(shared),
+                    "query_text_template_file": str(shared),
+                },
+            ],
+        )
+
+
+def test_category_queries__values_query_template_file_missing_path_fails(tmp_path):
+    with pytest.raises(ValidationError):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values_query_template_file": str(tmp_path / "nope.json")},
+            ],
+        )
+
+
+def test_check_no_empty_values__accepts_none_after_values_made_optional(tmp_path):
+    """Regression: when values is `None` (engine-discovery mode) the field validator must not crash."""
+    facet = _write_solr_facet_template(tmp_path)
+    # If `check_no_empty_values` doesn't accept None, this would raise during model construction.
+    Config(
+        **_base_cfg_kwargs(tmp_path),
+        category_queries=[
+            {"fields": ["genres"], "values_query_template_file": str(facet)},
+        ],
+    )
+
+
+def test_path_collision_validator_runs_before_placeholder_content_validator(tmp_path):
+    """Pointing query_text_template_file at a value-discovery JSON file must produce the
+    informative 'different concepts' error, not a misleading 'missing placeholder' one.
+
+    Without correct validator ordering, placeholder validation runs first and complains that
+    the JSON file is missing `$query`, masking the actual mistake.
+    """
+    shared = tmp_path / "shared.json"
+    shared.write_text('{"q": "*:*"}\n', encoding="utf-8")
+    with pytest.raises(ValidationError) as exc:
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {
+                    "fields": ["genres"],
+                    "values_query_template_file": str(shared),
+                    "query_text_template_file": str(shared),
+                },
+            ],
+        )
+    msg = str(exc.value)
+    assert "different concepts" in msg
+    assert "must contain the literal placeholder" not in msg
+
+
+def test_generate_queries_from_documents__null_fails_validation(tmp_path):
+    cfg_text = (
+        'search_engine_type: "solr"\n'
+        'collection_name: "testcore"\n'
+        'search_engine_url: "http://localhost:8983/solr/"\n'
+        'number_of_docs: 1\n'
+        'doc_fields: ["title"]\n'
+        'num_queries_needed: 1\n'
+        'relevance_scale: "graded"\n'
+        'llm_configuration_file: "tests/resources/llm_config.yaml"\n'
+        'output_format: "quepid"\n'
+        'output_destination: "output"\n'
+        'generate_queries_from_documents: null\n'
+    )
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(cfg_text, encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        Config.load(str(cfg_path))

--- a/rre-tools/tests/dataset_generator/test_config_dataset_generator.py
+++ b/rre-tools/tests/dataset_generator/test_config_dataset_generator.py
@@ -77,6 +77,29 @@ def test_mteb_config__expects__successful_load(resource_folder):
     assert mteb_config.output_format == "mteb"
     assert mteb_config.output_destination == Path("output")
 
+
+def test_vespa_config_without_schema__expects__schema_defaults_to_collection_name(tmp_path):
+    cfg_text = (
+        "search_engine_type: \"vespa\"\n"
+        "collection_name: \"movie\"\n"
+        "search_engine_url: \"http://localhost:8080/search/\"\n"
+        "number_of_docs: 2\n"
+        "doc_fields: [\"title\"]\n"
+        "num_queries_needed: 2\n"
+        "relevance_scale: \"binary\"\n"
+        "llm_configuration_file: \"tests/resources/llm_config.yaml\"\n"
+        "output_format: \"quepid\"\n"
+        "output_destination: \"output\"\n"
+    )
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(cfg_text, encoding="utf-8")
+
+    cfg = Config.load(str(cfg_path))
+
+    assert cfg.vespa_schema == "movie"
+    assert cfg.search_engine_collection_endpoint == HttpUrl("http://localhost:8080/search/movie/")
+
+
 def test_missing_both_templates_with_rre__expects__raises_validation_error(resource_folder):
     file_name = "missing_both_templates.yaml"
     with pytest.raises(ValidationError):

--- a/rre-tools/tests/dataset_generator/test_main_autosave.py
+++ b/rre-tools/tests/dataset_generator/test_main_autosave.py
@@ -44,6 +44,7 @@ max_tokens: 16
         rre_query_placeholder=None,
         verbose=False,
         datastore_autosave_every_n_updates=7,
+        enable_cartesian_product=False,
     )
 
     # Patch Config.load to return our in-memory cfg (bypass reading from disk)
@@ -58,8 +59,9 @@ max_tokens: 16
     monkeypatch.setattr(main_mod, "LLMServiceFactory", types.SimpleNamespace(build=lambda _cfg: object()))
     monkeypatch.setattr(main_mod, "WriterFactory", types.SimpleNamespace(build=lambda _cfg: DummyWriter()))
 
-    # No-op the heavy flow functions to keep the test focused on wiring
-    monkeypatch.setattr(main_mod, "generate_and_add_queries", lambda *args, **kwargs: None)
+    # With both `generate_queries_from_documents=False` and `enable_cartesian_product=False`,
+    # seed-fetch and LLM-gen paths are gated off; top-K is short-circuited by `query_template=None`.
+    # Defensive no-ops kept for the remaining flow functions in case gating changes in the future.
     monkeypatch.setattr(main_mod, "add_cartesian_product_scores", lambda *args, **kwargs: None)
     monkeypatch.setattr(main_mod, "expand_docset_with_search_engine_top_k", lambda *args, **kwargs: None)
 

--- a/rre-tools/tests/dataset_generator/test_main_category_wiring.py
+++ b/rre-tools/tests/dataset_generator/test_main_category_wiring.py
@@ -1,0 +1,220 @@
+from rre_tools.dataset_generator import main as main_mod
+from rre_tools.shared.data_store import DataStore
+from rre_tools.shared.models import Document
+
+from tests.dataset_generator.category_query_test_utils import (
+    FakeLLMService,
+    FakeSearchEngine,
+    genre_query_template,
+    make_config,
+    patch_main_dependencies,
+)
+
+
+def test_main__category_only_skips_llm_gen_and_still_fetches_seeds_for_cartesian(tmp_path, monkeypatch):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=False,
+        enable_cartesian_product=True,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+        ],
+    )
+
+    seed_doc = Document(id="d1", fields={"title": "Some movie", "genres": ["comedy"]})
+    engine = FakeSearchEngine([seed_doc])
+    llm = FakeLLMService()
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm)
+
+    captured = {}
+
+    class _DataStoreCapture(DataStore):
+        def __init__(self, *a, **kw):
+            super().__init__(path=tmp_path / "ds.json", ignore_saved_data=True,
+                             autosave_every_n_updates=kw.get("autosave_every_n_updates"))
+            captured["ds"] = self
+
+    monkeypatch.setattr(main_mod, "DataStore", _DataStoreCapture)
+
+    main_mod.main()
+
+    ds = captured["ds"]
+    assert any(q.text == "comedy movies" for q in ds.get_queries())
+    assert engine.fetch_calls == 1
+    assert "d1" in {d.id for d in ds.get_cartesian_prod_docs()}
+    assert llm.generate_queries_calls == []
+
+
+def test_main__engine_discovery_with_cartesian_produces_ratings(tmp_path, monkeypatch):
+    facet = tmp_path / "facet_solr.json"
+    facet.write_text('{"q": "*:*", "facet": "true", "facet.field": "genres", "rows": 0}\n', encoding="utf-8")
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=False,
+        enable_cartesian_product=True,
+        category_queries=[
+            {"fields": ["genres"], "values_query_template_file": str(facet),
+             "query_text_template_file": str(template)},
+        ],
+    )
+
+    seed_doc = Document(id="d1", fields={"title": "Some movie", "genres": ["comedy"]})
+
+    class _DiscoveryEngine:
+        def __init__(self):
+            self.fetch_calls = 0
+            self.value_calls = 0
+
+        def fetch_for_query_generation(self, documents_filter, number_of_docs, doc_fields):
+            self.fetch_calls += 1
+            return [seed_doc]
+
+        def fetch_field_values(self, values_query_template, field):
+            self.value_calls += 1
+            return ["comedy"]
+
+    engine = _DiscoveryEngine()
+    llm = FakeLLMService(score=2)
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm, stub_cartesian=False)
+
+    captured = {}
+
+    class _DataStoreCapture(DataStore):
+        def __init__(self, *a, **kw):
+            super().__init__(path=tmp_path / "ds.json", ignore_saved_data=True,
+                             autosave_every_n_updates=kw.get("autosave_every_n_updates"))
+            captured["ds"] = self
+
+    monkeypatch.setattr(main_mod, "DataStore", _DataStoreCapture)
+
+    main_mod.main()
+
+    ds = captured["ds"]
+    category_query = next(q for q in ds.get_queries() if q.text == "comedy movies")
+
+    assert engine.value_calls == 1
+    assert engine.fetch_calls == 1
+    assert llm.generate_score_calls == [("d1", "comedy movies")]
+    rating = ds.rating_by_pair.get((category_query.id, "d1"))
+    assert rating is not None
+    assert rating.score == 2
+
+
+def test_main__category_query_rated_against_seed_doc_via_cartesian(tmp_path, monkeypatch):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=False,
+        enable_cartesian_product=True,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+        ],
+    )
+
+    seed_doc = Document(id="d1", fields={"title": "Some movie", "genres": ["comedy"]})
+    engine = FakeSearchEngine([seed_doc])
+    llm = FakeLLMService(score=2)
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm, stub_cartesian=False)
+
+    captured = {}
+
+    class _DataStoreCapture(DataStore):
+        def __init__(self, *a, **kw):
+            super().__init__(path=tmp_path / "ds.json", ignore_saved_data=True,
+                             autosave_every_n_updates=kw.get("autosave_every_n_updates"))
+            captured["ds"] = self
+
+    monkeypatch.setattr(main_mod, "DataStore", _DataStoreCapture)
+
+    main_mod.main()
+
+    ds = captured["ds"]
+    category_query = next(q for q in ds.get_queries() if q.text == "comedy movies")
+
+    assert llm.generate_score_calls == [("d1", "comedy movies")]
+    rating = ds.rating_by_pair.get((category_query.id, "d1"))
+    assert rating is not None
+    assert rating.score == 2
+
+
+def test_main__both_flags_off_does_not_call_search_engine(tmp_path, monkeypatch):
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=False,
+        enable_cartesian_product=False,
+    )
+
+    engine = FakeSearchEngine([Document(id="d1", fields={"title": "t"})])
+    llm = FakeLLMService()
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm)
+    monkeypatch.setattr(main_mod, "DataStore",
+                        lambda **kw: DataStore(path=tmp_path / "ds.json", ignore_saved_data=True,
+                                               autosave_every_n_updates=kw.get("autosave_every_n_updates")))
+
+    main_mod.main()
+
+    assert engine.fetch_calls == 0
+    assert llm.generate_queries_calls == []
+
+
+def test_main__llm_gen_reuses_seed_docs_no_double_fetch(tmp_path, monkeypatch):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=True,
+        enable_cartesian_product=True,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+        ],
+        num_queries_needed=10,
+        number_of_docs=1,
+    )
+
+    seed = Document(id="d1", fields={"title": "Some movie", "genres": ["comedy"]})
+    engine = FakeSearchEngine([seed])
+    llm = FakeLLMService(queries_per_doc={"d1": ["q-from-doc"]})
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm)
+    monkeypatch.setattr(main_mod, "DataStore",
+                        lambda **kw: DataStore(path=tmp_path / "ds.json", ignore_saved_data=True,
+                                               autosave_every_n_updates=kw.get("autosave_every_n_updates")))
+
+    main_mod.main()
+
+    assert engine.fetch_calls == 1
+    assert llm.generate_queries_calls == ["d1"]
+
+
+def test_main__category_fills_budget_then_llm_gen_skipped(tmp_path, monkeypatch):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=True,
+        enable_cartesian_product=True,
+        category_queries=[
+            {"fields": ["genres"],
+             "values": ["comedy", "action", "horror"],
+             "query_text_template_file": str(template)},
+        ],
+        num_queries_needed=2,
+        number_of_docs=1,
+    )
+
+    engine = FakeSearchEngine([Document(id="d1", fields={"title": "t", "genres": ["comedy"]})])
+    llm = FakeLLMService(queries_per_doc={"d1": ["should-not-be-added"]})
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm)
+    monkeypatch.setattr(main_mod, "DataStore",
+                        lambda **kw: DataStore(path=tmp_path / "ds.json", ignore_saved_data=True,
+                                               autosave_every_n_updates=kw.get("autosave_every_n_updates")))
+
+    main_mod.main()
+
+    assert engine.fetch_calls == 1
+    assert llm.generate_queries_calls == []

--- a/rre-tools/tests/dataset_generator/test_main_query_budget.py
+++ b/rre-tools/tests/dataset_generator/test_main_query_budget.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from rre_tools.dataset_generator.main import add_cartesian_product_scores, expand_docset_with_search_engine_top_k
+from rre_tools.shared.data_store import DataStore
+from rre_tools.shared.models import Document
+
+
+class FakeLLMService:
+    def __init__(self):
+        self.calls = []
+
+    def generate_score(self, document, query, relevance_scale, explanation=False):
+        self.calls.append((document.id, query, relevance_scale, explanation))
+        return SimpleNamespace(score=1, explanation=None, get_score=lambda: 1)
+
+
+class FakeSearchEngine:
+    def __init__(self):
+        self.queries = []
+
+    def fetch_for_evaluation(self, keyword, query_template, doc_fields):
+        self.queries.append(keyword)
+        return [Document(id=f"doc-{keyword}", fields={"title": [keyword]})]
+
+
+def _config(**overrides):
+    values = {
+        "num_queries_needed": 2,
+        "query_template": "select * from test where userInput(@kw)",
+        "doc_fields": ["title"],
+        "relevance_scale": "graded",
+        "save_llm_explanation": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_expand_docset_with_search_engine_top_k__expects__query_budget_respected():
+    data_store = DataStore(ignore_saved_data=True)
+    for query in ["q1", "q2", "q3"]:
+        data_store.add_query(query)
+
+    llm_service = FakeLLMService()
+    search_engine = FakeSearchEngine()
+
+    expand_docset_with_search_engine_top_k(_config(), data_store, llm_service, search_engine)
+
+    assert search_engine.queries == ["q1", "q2"]
+    assert [call[1] for call in llm_service.calls] == ["q1", "q2"]
+
+
+def test_add_cartesian_product_scores__expects__query_budget_respected():
+    data_store = DataStore(ignore_saved_data=True)
+    for query in ["q1", "q2", "q3"]:
+        data_store.add_query(query)
+    for doc_id in ["d1", "d2"]:
+        data_store.add_document(Document(id=doc_id, fields={"title": [doc_id]}, is_used_to_generate_queries=True))
+
+    llm_service = FakeLLMService()
+
+    add_cartesian_product_scores(_config(), data_store, llm_service)
+
+    assert [call[1] for call in llm_service.calls] == ["q1", "q1", "q2", "q2"]

--- a/rre-tools/tests/dataset_generator/test_main_query_budget.py
+++ b/rre-tools/tests/dataset_generator/test_main_query_budget.py
@@ -1,6 +1,10 @@
 from types import SimpleNamespace
 
-from rre_tools.dataset_generator.main import add_cartesian_product_scores, expand_docset_with_search_engine_top_k
+from rre_tools.dataset_generator.main import (
+    add_cartesian_product_scores,
+    expand_docset_with_search_engine_top_k,
+    get_queries_within_budget,
+)
 from rre_tools.shared.data_store import DataStore
 from rre_tools.shared.models import Document
 
@@ -61,3 +65,50 @@ def test_add_cartesian_product_scores__expects__query_budget_respected():
     add_cartesian_product_scores(_config(), data_store, llm_service)
 
     assert [call[1] for call in llm_service.calls] == ["q1", "q1", "q2", "q2"]
+
+
+def test_get_queries_within_budget__prioritizes_user_and_category_over_cached():
+    """Regression: when the cache is full, fresh user/category queries must still make the cut.
+
+    Pre-fix bug: get_queries_within_budget did `queries[:N]` which is purely positional, so
+    cached queries (loaded first into the dict) saturated the budget and category/user queries
+    appended later were silently dropped from scoring.
+    """
+    data_store = DataStore(ignore_saved_data=True)
+    for q in ["cached1", "cached2", "cached3"]:
+        data_store.add_query(q)  # default 'cached'
+    data_store.add_query("user1", source="user")
+    data_store.add_query("category1", source="category")
+
+    selected = get_queries_within_budget(_config(num_queries_needed=2), data_store)
+    selected_texts = [q.text for q in selected]
+    assert selected_texts == ["user1", "category1"]
+
+
+def test_get_queries_within_budget__within_tier_keeps_insertion_order():
+    """Within the same priority tier, the original insertion order is preserved."""
+    data_store = DataStore(ignore_saved_data=True)
+    data_store.add_query("u_first", source="user")
+    data_store.add_query("c_first", source="category")
+    data_store.add_query("u_second", source="user")
+
+    selected = get_queries_within_budget(_config(num_queries_needed=3), data_store)
+    assert [q.text for q in selected] == ["u_first", "c_first", "u_second"]
+
+
+def test_get_queries_within_budget__llm_outranks_cached():
+    data_store = DataStore(ignore_saved_data=True)
+    for q in ["cached1", "cached2"]:
+        data_store.add_query(q)
+    data_store.add_query("llm1", source="llm")
+
+    selected = get_queries_within_budget(_config(num_queries_needed=1), data_store)
+    assert [q.text for q in selected] == ["llm1"]
+
+
+def test_get_queries_within_budget__truncates_to_num_queries_needed():
+    data_store = DataStore(ignore_saved_data=True)
+    for q in ["a", "b", "c"]:
+        data_store.add_query(q)
+    selected = get_queries_within_budget(_config(num_queries_needed=2), data_store)
+    assert [q.text for q in selected] == ["a", "b"]

--- a/rre-tools/tests/dataset_generator/test_seed_fetch_llm_generation.py
+++ b/rre-tools/tests/dataset_generator/test_seed_fetch_llm_generation.py
@@ -1,0 +1,116 @@
+from rre_tools.dataset_generator import main as main_mod
+from rre_tools.shared.data_store import DataStore
+from rre_tools.shared.models import Document
+
+from tests.dataset_generator.category_query_test_utils import (
+    FakeLLMService,
+    FakeSearchEngine,
+    make_config,
+)
+
+
+def test_fetch_and_add_seed_documents__marks_cache_hit_doc_for_cartesian(tmp_path):
+    cfg = make_config(tmp_path)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    cached = Document(id="d1", fields={"title": "t"}, is_used_to_generate_queries=False)
+    ds.add_document(cached)
+
+    fetched = Document(id="d1", fields={"title": "t"})
+    engine = FakeSearchEngine([fetched])
+
+    main_mod.fetch_and_add_seed_documents(cfg, ds, engine)
+
+    assert "d1" in {d.id for d in ds.get_cartesian_prod_docs()}
+
+
+def test_fetch_and_add_seed_documents__new_docs_flagged(tmp_path):
+    cfg = make_config(tmp_path)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([Document(id="d1", fields={"title": "t1"})])
+
+    main_mod.fetch_and_add_seed_documents(cfg, ds, engine)
+
+    assert ds.get_document("d1").is_used_to_generate_queries is True
+
+
+def test_generate_and_add_queries_from_documents__cached_queries_do_not_block_llm_gen(tmp_path):
+    cfg = make_config(tmp_path, num_queries_needed=2, number_of_docs=1)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    for i in range(5):
+        ds.add_query(f"cached{i}")
+    seed = Document(id="d1", fields={"title": "t1"}, is_used_to_generate_queries=True)
+    ds.add_document(seed)
+
+    llm = FakeLLMService(queries_per_doc={"d1": ["fresh-llm-query"]})
+
+    main_mod.generate_and_add_queries_from_documents(cfg, ds, llm, [seed])
+
+    assert llm.generate_queries_calls == ["d1"]
+    fresh = next((q for q in ds.get_queries() if q.text == "fresh-llm-query"), None)
+    assert fresh is not None
+    assert fresh.source == "llm"
+
+
+def test_generate_and_add_queries_from_documents__existing_llm_queries_count_against_budget(tmp_path):
+    cfg = make_config(tmp_path, num_queries_needed=2, number_of_docs=1)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    ds.add_query("pre-llm-1", source="llm")
+    ds.add_query("pre-llm-2", source="llm")
+    seed = Document(id="d1", fields={"title": "t1"}, is_used_to_generate_queries=True)
+    ds.add_document(seed)
+
+    llm = FakeLLMService(queries_per_doc={"d1": ["should-not-be-generated"]})
+
+    main_mod.generate_and_add_queries_from_documents(cfg, ds, llm, [seed])
+
+    assert llm.generate_queries_calls == []
+    assert not any(q.text == "should-not-be-generated" for q in ds.get_queries())
+
+
+def test_generate_and_add_queries_from_documents__no_extra_llm_call_after_inner_loop_fills_budget(tmp_path):
+    cfg = make_config(tmp_path, num_queries_needed=1, number_of_docs=1)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    seed1 = Document(id="d1", fields={"title": "t1"}, is_used_to_generate_queries=True)
+    seed2 = Document(id="d2", fields={"title": "t2"}, is_used_to_generate_queries=True)
+    ds.add_document(seed1)
+    ds.add_document(seed2)
+
+    llm = FakeLLMService(queries_per_doc={"d1": ["q1"], "d2": ["q2"]})
+
+    main_mod.generate_and_add_queries_from_documents(cfg, ds, llm, [seed1, seed2])
+
+    assert llm.generate_queries_calls == ["d1"]
+
+
+def test_generate_and_add_queries_from_documents__user_and_category_fill_budget_skip_llm(tmp_path):
+    cfg = make_config(tmp_path, num_queries_needed=2, number_of_docs=1)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    ds.add_query("u1", source="user")
+    ds.add_query("c1", source="category")
+    seed = Document(id="d1", fields={"title": "t1"}, is_used_to_generate_queries=True)
+    ds.add_document(seed)
+
+    llm = FakeLLMService(queries_per_doc={"d1": ["never-added"]})
+
+    main_mod.generate_and_add_queries_from_documents(cfg, ds, llm, [seed])
+
+    assert llm.generate_queries_calls == []
+    assert not any(q.text == "never-added" for q in ds.get_queries())
+
+
+def test_generate_and_add_queries_from_documents__pre_rates_seed_doc_with_max(tmp_path):
+    cfg = make_config(tmp_path, num_queries_needed=2, number_of_docs=1)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    seed = Document(id="d1", fields={"title": "t1"}, is_used_to_generate_queries=True)
+    ds.add_document(seed)
+
+    llm = FakeLLMService(queries_per_doc={"d1": ["the synthetic query"]})
+
+    main_mod.generate_and_add_queries_from_documents(cfg, ds, llm, [seed])
+
+    queries = ds.get_queries()
+    assert any(q.text == "the synthetic query" for q in queries)
+    generated = next(q for q in queries if q.text == "the synthetic query")
+    rating = ds.rating_by_pair.get((generated.id, "d1"))
+    assert rating is not None
+    assert rating.score == max(cfg.relevance_label_set)

--- a/rre-tools/tests/shared/search_engines/test_fetch_field_values.py
+++ b/rre-tools/tests/shared/search_engines/test_fetch_field_values.py
@@ -1,0 +1,416 @@
+"""Per-engine `fetch_field_values` tests (engine-driven value discovery).
+
+Each engine's `fetch_field_values` is a separate code path from `_search` (different
+return type, different transport, raw response navigation), so these tests stub
+`requests.get` (Solr) or `requests.post` (ES/OS/Vespa) directly.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import requests
+from requests.exceptions import HTTPError
+
+from rre_tools.shared.search_engines import (
+    ElasticsearchSearchEngine,
+    OpenSearchEngine,
+    SolrSearchEngine,
+    VespaSearchEngine,
+)
+
+
+# ─────────────── shared HTTP-stub helpers ───────────────
+
+class _Resp:
+    def __init__(self, body, status_code=200):
+        self._body = body
+        self.status_code = status_code
+
+    def json(self):
+        return self._body
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise HTTPError(f"status {self.status_code}")
+
+    @property
+    def request(self):
+        # Used by Solr code path's debug log; not asserted on.
+        return type("_Req", (), {"url": "stubbed"})()
+
+
+def _capture_get(monkeypatch, body, status_code=200):
+    calls = {}
+
+    def _get(url, headers=None, params=None, **kwargs):
+        calls["url"] = url
+        calls["headers"] = headers
+        calls["params"] = params
+        calls["kwargs"] = kwargs
+        return _Resp(body, status_code)
+
+    monkeypatch.setattr(requests, "get", _get)
+    return calls
+
+
+def _capture_post(monkeypatch, body, status_code=200):
+    calls = {}
+
+    def _post(url, headers=None, json=None, **kwargs):
+        calls["url"] = url
+        calls["headers"] = headers
+        calls["json"] = json
+        calls["kwargs"] = kwargs
+        return _Resp(body, status_code)
+
+    monkeypatch.setattr(requests, "post", _post)
+    return calls
+
+
+# Solr engine `__init__` issues a GET to fetch the unique key. Avoid hitting the network.
+@pytest.fixture
+def solr_engine(monkeypatch):
+    monkeypatch.setattr(
+        requests, "get",
+        lambda *a, **kw: _Resp({"uniqueKey": "id"}),
+    )
+    return SolrSearchEngine("http://fake-solr/collection/")
+
+
+# ───────────────── Solr ─────────────────
+
+
+def _write_solr_facet_template(tmp_path: Path) -> Path:
+    p = tmp_path / "facet_solr.json"
+    p.write_text(
+        json.dumps({"q": "*:*", "facet": "true", "facet.field": "genres", "facet.limit": 5, "rows": 0}),
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_solr_fetch_field_values__alternating_array_drops_counts_preserves_order(solr_engine, monkeypatch, tmp_path):
+    body = {"facet_counts": {"facet_fields": {"genres": ["comedy", 12, "action", 4, "drama", 1]}}}
+    calls = _capture_get(monkeypatch, body)
+    template = _write_solr_facet_template(tmp_path)
+
+    values = solr_engine.fetch_field_values(template, "genres")
+
+    assert values == ["comedy", "action", "drama"]
+    assert calls["url"].endswith("/select")
+    assert calls["params"]["wt"] == "json"
+    assert calls["params"]["facet.field"] == "genres"
+
+
+def test_solr_fetch_field_values__numeric_values_coerce_and_whitespace_dropped(solr_engine, monkeypatch, tmp_path):
+    body = {"facet_counts": {"facet_fields": {"year": [2020, 9, 2021, 4, "  ", 1, "   2022 ", 1]}}}
+    _capture_get(monkeypatch, body)
+    template = _write_solr_facet_template(tmp_path)
+
+    values = solr_engine.fetch_field_values(template, "year")
+
+    assert values == ["2020", "2021", "2022"]
+
+
+def test_solr_fetch_field_values__missing_facet_counts_raises(solr_engine, monkeypatch, tmp_path):
+    _capture_get(monkeypatch, {"response": {"docs": []}})
+    template = _write_solr_facet_template(tmp_path)
+    with pytest.raises(ValueError, match="facet_counts"):
+        solr_engine.fetch_field_values(template, "genres")
+
+
+def test_solr_fetch_field_values__wrong_field_key_raises(solr_engine, monkeypatch, tmp_path):
+    _capture_get(monkeypatch, {"facet_counts": {"facet_fields": {"category": ["x", 1]}}})
+    template = _write_solr_facet_template(tmp_path)
+    with pytest.raises(ValueError, match="genres"):
+        solr_engine.fetch_field_values(template, "genres")
+
+
+def test_solr_fetch_field_values__field_not_a_list_raises(solr_engine, monkeypatch, tmp_path):
+    _capture_get(monkeypatch, {"facet_counts": {"facet_fields": {"genres": "comedy,action"}}})
+    template = _write_solr_facet_template(tmp_path)
+    with pytest.raises(ValueError, match="must be a list"):
+        solr_engine.fetch_field_values(template, "genres")
+
+
+def test_solr_fetch_field_values__odd_length_array_raises(solr_engine, monkeypatch, tmp_path):
+    _capture_get(monkeypatch, {"facet_counts": {"facet_fields": {"genres": ["comedy", 1, "action"]}}})
+    template = _write_solr_facet_template(tmp_path)
+    with pytest.raises(ValueError, match="even length"):
+        solr_engine.fetch_field_values(template, "genres")
+
+
+def test_solr_fetch_field_values__empty_array_returns_empty_list_silently(solr_engine, monkeypatch, tmp_path, caplog):
+    _capture_get(monkeypatch, {"facet_counts": {"facet_fields": {"genres": []}}})
+    template = _write_solr_facet_template(tmp_path)
+    with caplog.at_level("WARNING"):
+        values = solr_engine.fetch_field_values(template, "genres")
+    assert values == []
+    # No engine-side warning — the single warning lives in add_category_queries.
+    assert not [r for r in caplog.records if "no values" in r.getMessage()]
+
+
+def test_solr_fetch_field_values__http_error_propagates(solr_engine, monkeypatch, tmp_path):
+    _capture_get(monkeypatch, {}, status_code=500)
+    template = _write_solr_facet_template(tmp_path)
+    with pytest.raises(HTTPError):
+        solr_engine.fetch_field_values(template, "genres")
+
+
+def test_solr_fetch_field_values__does_not_route_through_search(solr_engine, monkeypatch, tmp_path):
+    """fetch_field_values must not call self._search() (which parses hits and discards
+    facet_counts). Greppable contract from the plan."""
+    body = {"facet_counts": {"facet_fields": {"genres": ["comedy", 1]}}}
+    _capture_get(monkeypatch, body)
+
+    sentinel = {"called": False}
+
+    def _spy_search(*a, **kw):
+        sentinel["called"] = True
+        raise AssertionError("_search should not be called")
+
+    monkeypatch.setattr(solr_engine, "_search", _spy_search)
+    template = _write_solr_facet_template(tmp_path)
+    solr_engine.fetch_field_values(template, "genres")
+    assert sentinel["called"] is False
+
+
+# ───────────────── Elasticsearch ─────────────────
+
+
+def _write_es_agg_template(tmp_path: Path) -> Path:
+    p = tmp_path / "facet_es.json"
+    p.write_text(
+        json.dumps({
+            "size": 0,
+            "aggs": {"genres": {"terms": {"field": "genres.keyword", "size": 5}}}
+        }),
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_es_fetch_field_values__buckets_returned_in_order(monkeypatch, tmp_path):
+    body = {
+        "aggregations": {
+            "genres": {"buckets": [
+                {"key": "comedy", "doc_count": 12},
+                {"key": "action", "doc_count": 4},
+            ]}
+        }
+    }
+    calls = _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+
+    values = engine.fetch_field_values(template, "genres")
+
+    assert values == ["comedy", "action"]
+    assert calls["url"].endswith("/_search")
+    # The internal terms.field stays `genres.keyword` (convention navigates by result key).
+    assert calls["json"]["aggs"]["genres"]["terms"]["field"] == "genres.keyword"
+
+
+def test_es_fetch_field_values__numeric_and_boolean_keys_coerce(monkeypatch, tmp_path):
+    body = {"aggregations": {"is_premium": {"buckets": [
+        {"key": True, "doc_count": 9},
+        {"key": False, "doc_count": 1},
+    ]}}}
+    _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+
+    assert engine.fetch_field_values(template, "is_premium") == ["True", "False"]
+
+
+def test_es_fetch_field_values__mismatched_agg_key_raises_with_convention_message(monkeypatch, tmp_path):
+    body = {"aggregations": {"category": {"buckets": [{"key": "comedy"}]}}}  # named 'category', not 'genres'
+    _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+
+    with pytest.raises(ValueError, match="aggregation result key must equal"):
+        engine.fetch_field_values(template, "genres")
+
+
+def test_es_fetch_field_values__keyed_buckets_form_raises(monkeypatch, tmp_path):
+    """`"keyed": true` returns buckets as a dict; unsupported."""
+    body = {"aggregations": {"genres": {"buckets": {"comedy": {"doc_count": 12}}}}}
+    _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+
+    with pytest.raises(ValueError, match="Keyed-bucket"):
+        engine.fetch_field_values(template, "genres")
+
+
+def test_es_fetch_field_values__empty_buckets_returns_empty_list_silently(monkeypatch, tmp_path):
+    body = {"aggregations": {"genres": {"buckets": []}}}
+    _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+    assert engine.fetch_field_values(template, "genres") == []
+
+
+def test_es_fetch_field_values__http_error_propagates(monkeypatch, tmp_path):
+    _capture_post(monkeypatch, {}, status_code=500)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+    with pytest.raises(HTTPError):
+        engine.fetch_field_values(template, "genres")
+
+
+def test_es_agg_keyword_subfield_does_not_require_keyword_in_doc_fields(monkeypatch, tmp_path):
+    """Convention test: aggregating on `genres.keyword` while naming the agg `genres` is supported.
+    The result-key convention navigates by the agg's name, not its internal terms.field.
+    `doc_fields=[genres]` (no `.keyword`) is fine — no engine-level coupling exists between
+    the aggregation's internal field and Config.doc_fields.
+    """
+    body = {"aggregations": {"genres": {"buckets": [{"key": "comedy"}]}}}
+    _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+    assert engine.fetch_field_values(template, "genres") == ["comedy"]
+
+
+# ───────────────── OpenSearch ─────────────────
+
+
+def test_opensearch_fetch_field_values__mirrors_es_behaviour(monkeypatch, tmp_path):
+    body = {"aggregations": {"genres": {"buckets": [{"key": "drama"}, {"key": "horror"}]}}}
+    _capture_post(monkeypatch, body)
+    engine = OpenSearchEngine("http://fake-os/index/")
+    template = _write_es_agg_template(tmp_path)
+    assert engine.fetch_field_values(template, "genres") == ["drama", "horror"]
+
+
+def test_opensearch_fetch_field_values__keyed_buckets_form_raises(monkeypatch, tmp_path):
+    body = {"aggregations": {"genres": {"buckets": {"drama": {"doc_count": 1}}}}}
+    _capture_post(monkeypatch, body)
+    engine = OpenSearchEngine("http://fake-os/index/")
+    template = _write_es_agg_template(tmp_path)
+    with pytest.raises(ValueError, match="Keyed-bucket"):
+        engine.fetch_field_values(template, "genres")
+
+
+# ───────────────── Vespa ─────────────────
+
+
+def _write_vespa_yql(tmp_path: Path) -> Path:
+    p = tmp_path / "facet_vespa.yql"
+    p.write_text(
+        "select * from sources * where true | all(group(genres) max(5) each(output(count())))\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _vespa_grouping_response(field: str, values_with_counts):
+    """Build a canonical Vespa grouping response shape."""
+    bucket_children = [
+        {
+            "id": f"group:string:{v}",
+            "value": v,
+            "fields": {"count()": c},
+        }
+        for v, c in values_with_counts
+    ]
+    return {
+        "root": {
+            "id": "toplevel",
+            "children": [
+                {
+                    "id": "group:root:0",
+                    "children": [
+                        {
+                            "id": f"grouplist:{field}",
+                            "label": field,
+                            "children": bucket_children,
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+
+
+def test_vespa_fetch_field_values__canonical_response_returns_values(monkeypatch, tmp_path):
+    body = _vespa_grouping_response("genres", [("comedy", 12), ("action", 4)])
+    calls = _capture_post(monkeypatch, body)
+    engine = VespaSearchEngine("http://fake-vespa/movie/")
+    template = _write_vespa_yql(tmp_path)
+
+    values = engine.fetch_field_values(template, "genres")
+
+    assert values == ["comedy", "action"]
+    assert calls["url"].endswith("/search/")
+    assert calls["json"]["hits"] == 0
+    assert calls["json"]["presentation.format"] == "json"
+    assert "group(genres)" in calls["json"]["yql"]
+
+
+def test_vespa_fetch_field_values__missing_grouplist_raises_with_seen_nodes(monkeypatch, tmp_path):
+    body = {"root": {"id": "toplevel", "children": [
+        {"id": "group:root:0", "children": [{"id": "grouplist:other"}]}
+    ]}}
+    _capture_post(monkeypatch, body)
+    engine = VespaSearchEngine("http://fake-vespa/movie/")
+    template = _write_vespa_yql(tmp_path)
+
+    with pytest.raises(ValueError) as exc:
+        engine.fetch_field_values(template, "genres")
+    msg = str(exc.value)
+    assert "no grouplist found for field 'genres'" in msg
+    assert "attribute" in msg  # precondition reminder
+    assert "grouplist:other" in msg  # encountered nodes captured
+
+
+def test_vespa_fetch_field_values__deeply_nested_grouplist_resolved_by_recursive_walk(monkeypatch, tmp_path):
+    """The recursive walk must find a grouplist that sits one level deeper than the canonical
+    layout — real Vespa responses sometimes nest the grouplist below the `group:root:0` node."""
+    body = {
+        "root": {
+            "id": "toplevel",
+            "children": [
+                {
+                    "id": "group:root:0",
+                    "children": [
+                        {
+                            "id": "wrapper",
+                            "children": [
+                                {
+                                    "id": "grouplist:genres",
+                                    "label": "genres",
+                                    "children": [
+                                        {"id": "group:string:noir", "value": "noir"},
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+    _capture_post(monkeypatch, body)
+    engine = VespaSearchEngine("http://fake-vespa/movie/")
+    template = _write_vespa_yql(tmp_path)
+    assert engine.fetch_field_values(template, "genres") == ["noir"]
+
+
+def test_vespa_fetch_field_values__empty_grouplist_returns_empty_list_silently(monkeypatch, tmp_path):
+    body = _vespa_grouping_response("genres", [])
+    _capture_post(monkeypatch, body)
+    engine = VespaSearchEngine("http://fake-vespa/movie/")
+    template = _write_vespa_yql(tmp_path)
+    assert engine.fetch_field_values(template, "genres") == []
+
+
+def test_vespa_fetch_field_values__http_error_propagates(monkeypatch, tmp_path):
+    _capture_post(monkeypatch, {}, status_code=500)
+    engine = VespaSearchEngine("http://fake-vespa/movie/")
+    template = _write_vespa_yql(tmp_path)
+    with pytest.raises(HTTPError):
+        engine.fetch_field_values(template, "genres")

--- a/rre-tools/tests/shared/search_engines/test_search_engine_factory.py
+++ b/rre-tools/tests/shared/search_engines/test_search_engine_factory.py
@@ -1,0 +1,21 @@
+import pytest
+from pydantic import HttpUrl
+
+from rre_tools.shared.search_engines import SearchEngineFactory, VespaSearchEngine
+
+
+def test_build_vespa__expects__vespa_search_engine():
+    search_engine = SearchEngineFactory.build(
+        search_engine_type="vespa",
+        endpoint=HttpUrl("http://localhost:8080/doc/"),
+    )
+
+    assert isinstance(search_engine, VespaSearchEngine)
+
+
+def test_build_unsupported_search_engine__expects__value_error():
+    with pytest.raises(ValueError, match="Unsupported search engine: unsupported"):
+        SearchEngineFactory.build(
+            search_engine_type="unsupported",
+            endpoint=HttpUrl("http://localhost:8080/doc/"),
+        )

--- a/rre-tools/tests/shared/search_engines/test_vespa_search_engine.py
+++ b/rre-tools/tests/shared/search_engines/test_vespa_search_engine.py
@@ -126,9 +126,13 @@ def test_fetch_for_query_generation__expects__builds_valid_yql_handles_hits_and_
     payload = calls["json"]
     assert payload["hits"] == number_of_docs
 
-    # YQL sanity
+    # YQL sanity: documentid is always projected (so `_search` can return the user doc id
+    # rather than the internal GID), alongside the requested fields.
     yql = payload["yql"]
-    assert re.search(r"select (title,\s*description|description,\s*title) from doc where ", yql)
+    assert re.search(r"^select [^f]+ from doc where ", yql)
+    assert "documentid" in yql
+    assert "title" in yql
+    assert "description" in yql
     assert 'title contains "Helicopter"' in yql
     assert ('(description contains "BOGOTA" OR description contains "Colombia")' in yql or
             '(description contains "Colombia" OR description contains "BOGOTA")' in yql)

--- a/rre-tools/tests/shared/test_data_store_mark_query_seed.py
+++ b/rre-tools/tests/shared/test_data_store_mark_query_seed.py
@@ -1,0 +1,45 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from rre_tools.shared.data_store import DataStore
+from rre_tools.shared.models import Document
+
+
+@pytest.fixture
+def tmp_db_path(tmp_path: Path) -> Path:
+    return tmp_path / "datastore.json"
+
+
+@pytest.fixture
+def ds(tmp_db_path: Path) -> DataStore:
+    return DataStore(path=tmp_db_path, ignore_saved_data=True)
+
+
+def test_mark_document_as_query_seed__flips_flag_when_false(ds):
+    doc = Document(id="d1", fields={"title": "t"}, is_used_to_generate_queries=False)
+    ds.add_document(doc)
+    assert ds.get_document("d1").is_used_to_generate_queries is False
+
+    ds.mark_document_as_query_seed("d1")
+    assert ds.get_document("d1").is_used_to_generate_queries is True
+    assert "d1" in {d.id for d in ds.get_cartesian_prod_docs()}
+
+
+def test_mark_document_as_query_seed__idempotent(ds):
+    doc = Document(id="d1", fields={"title": "t"}, is_used_to_generate_queries=False)
+    ds.add_document(doc)
+
+    ds.mark_document_as_query_seed("d1")
+    ds.mark_document_as_query_seed("d1")
+
+    assert ds.get_document("d1").is_used_to_generate_queries is True
+    assert len(ds.get_documents()) == 1
+
+
+def test_mark_document_as_query_seed__unknown_id_is_safe_noop(ds, caplog):
+    caplog.set_level(logging.WARNING)
+    ds.mark_document_as_query_seed("missing")
+    assert len(ds.get_documents()) == 0
+    assert any("doc_not_found" in rec.getMessage() for rec in caplog.records)

--- a/rre-tools/tests/shared/test_normalize_discovered_field_values.py
+++ b/rre-tools/tests/shared/test_normalize_discovered_field_values.py
@@ -1,0 +1,34 @@
+import pytest
+
+from rre_tools.shared.utils import normalize_discovered_field_values
+
+
+def test_normalize__drops_none():
+    assert normalize_discovered_field_values([None]) == []
+
+
+def test_normalize__drops_empty_and_whitespace_only():
+    assert normalize_discovered_field_values(["", "  "]) == []
+
+
+def test_normalize__strips_surrounding_whitespace():
+    assert normalize_discovered_field_values(["  comedy ", "action"]) == ["comedy", "action"]
+
+
+def test_normalize__coerces_int_float_bool_to_str():
+    assert normalize_discovered_field_values([123, 4.5, True]) == ["123", "4.5", "True"]
+
+
+def test_normalize__rejects_dict_with_value_error():
+    with pytest.raises(ValueError):
+        normalize_discovered_field_values([{"a": 1}])
+
+
+def test_normalize__rejects_list_with_value_error():
+    with pytest.raises(ValueError):
+        normalize_discovered_field_values([["nested"]])
+
+
+def test_normalize__preserves_input_order():
+    # No sort, no dedupe — DataStore.add_query handles cleaned-text dedupe.
+    assert normalize_discovered_field_values(["b", "a", "b"]) == ["b", "a", "b"]

--- a/rre-tools/tests/shared/test_query_source.py
+++ b/rre-tools/tests/shared/test_query_source.py
@@ -1,0 +1,87 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from rre_tools.shared.data_store import DataStore
+from rre_tools.shared.models import Query
+
+
+@pytest.fixture
+def tmp_db_path(tmp_path: Path) -> Path:
+    return tmp_path / "datastore.json"
+
+
+@pytest.fixture
+def ds(tmp_db_path: Path) -> DataStore:
+    return DataStore(path=tmp_db_path, ignore_saved_data=True)
+
+
+def test_add_query__default_source_is_cached(ds):
+    q = ds.add_query("hello world")
+    assert q.source == "cached"
+
+
+def test_add_query__explicit_source_is_set(ds):
+    q = ds.add_query("hello world", source="user")
+    assert q.source == "user"
+
+
+def test_add_query__promotes_cached_to_user(ds):
+    """Re-asserting a previously-cached query as user-supplied promotes its label."""
+    q1 = ds.add_query("comedy movies")  # default cached
+    assert q1.source == "cached"
+
+    q2 = ds.add_query("comedy movies", source="user")
+    assert q2 is q1  # dedup hit
+    assert q1.source == "user"
+
+
+def test_add_query__promotes_llm_to_category(ds):
+    q = ds.add_query("comedy movies", source="llm")
+    assert q.source == "llm"
+    ds.add_query("comedy movies", source="category")
+    assert q.source == "category"
+
+
+def test_add_query__does_not_demote_user_to_llm(ds):
+    """A user-asserted query must not be downgraded by a later LLM-gen with the same text."""
+    q = ds.add_query("comedy movies", source="user")
+    ds.add_query("comedy movies", source="llm")
+    assert q.source == "user"
+
+
+def test_add_query__does_not_demote_category_to_cached(ds):
+    q = ds.add_query("comedy movies", source="category")
+    ds.add_query("comedy movies")  # no source -> no-op on existing
+    assert q.source == "category"
+
+
+def test_query_source_not_persisted(tmp_path: Path):
+    """The source label is a runtime concern: it must not be written to the JSON cache."""
+    db_path = tmp_path / "datastore.json"
+    ds = DataStore(path=db_path, ignore_saved_data=True)
+    ds.add_query("comedy movies", source="user")
+    ds.save()
+
+    raw = json.loads(db_path.read_text(encoding="utf-8"))
+    assert raw["queries"]
+    assert all("source" not in entry for entry in raw["queries"])
+
+
+def test_query_source_resets_to_cached_on_load(tmp_path: Path):
+    """A user/category-labeled query saved in run 1 should load as 'cached' in run 2."""
+    db_path = tmp_path / "datastore.json"
+    ds = DataStore(path=db_path, ignore_saved_data=True)
+    ds.add_query("comedy movies", source="user")
+    ds.save()
+
+    reloaded = DataStore(path=db_path, ignore_saved_data=False)
+    qs = reloaded.get_queries()
+    assert len(qs) == 1
+    assert qs[0].source == "cached"
+
+
+def test_query_model__source_default():
+    q = Query(text="hi")
+    assert q.source == "cached"

--- a/rre-tools/tests/test_value_discovery_sample_templates.py
+++ b/rre-tools/tests/test_value_discovery_sample_templates.py
@@ -1,0 +1,73 @@
+"""Regression test: shipped value-discovery sample templates must be parseable by the engines
+that load them. Catches the comment-in-JSON foot-gun (and would catch a `#` header sneaking
+into the YQL sample).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import requests
+
+from rre_tools.shared.search_engines import SolrSearchEngine
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATES_DIR = REPO_ROOT / "templates"
+
+
+def test_genre_facet_solr_json__parses_via_engine_loader():
+    """Solr engine `_parse_query_template` is `json.load` under the hood — comments would break it."""
+    template = TEMPLATES_DIR / "genre_facet_solr.json"
+
+    class _Resp:
+        def json(self):
+            return {"uniqueKey": "id"}
+        def raise_for_status(self):
+            pass
+
+    # Solr engine `__init__` issues a GET to fetch the unique key. Skip it.
+    orig_get = requests.get
+    try:
+        requests.get = lambda *a, **kw: _Resp()  # type: ignore[assignment]
+        engine = SolrSearchEngine("http://fake-solr/collection/")
+    finally:
+        requests.get = orig_get
+
+    payload = engine._parse_query_template(template)
+    assert isinstance(payload, dict)
+    assert payload["facet.field"] == "genres"
+    assert "facet.limit" in payload
+    # Solr params must be scalars (str/int/bool) — `requests.get(..., params=)` requires it.
+    for k, v in payload.items():
+        assert isinstance(v, (str, int, float, bool)), f"Solr param {k!r} must be a scalar, got {type(v).__name__}"
+
+
+def test_genre_facet_es_json__parses_via_json_load_with_aggs_shape():
+    template = TEMPLATES_DIR / "genre_facet_es.json"
+    payload = json.loads(template.read_text(encoding="utf-8"))
+    # Request body shape: `aggs` (not `aggregations` — that's the response key).
+    assert "aggs" in payload
+    # Convention: agg result key equals the field we'll be querying on.
+    assert "genres" in payload["aggs"]
+    assert "terms" in payload["aggs"]["genres"]
+    assert "field" in payload["aggs"]["genres"]["terms"]
+
+
+def test_genre_facet_opensearch_json__same_shape_as_es():
+    template = TEMPLATES_DIR / "genre_facet_opensearch.json"
+    payload = json.loads(template.read_text(encoding="utf-8"))
+    assert "aggs" in payload
+    assert "genres" in payload["aggs"]
+    assert "terms" in payload["aggs"]["genres"]
+    assert "field" in payload["aggs"]["genres"]["terms"]
+
+
+def test_genre_facet_vespa_yql__plain_text_no_hash_comments():
+    """The YQL sample is sent to Vespa verbatim. A `#` line would be parsed as part of the
+    query (or rejected). Disallow them in the shipped file."""
+    text = (TEMPLATES_DIR / "genre_facet_vespa.yql").read_text(encoding="utf-8")
+    assert "group(genres)" in text
+    for ln in text.splitlines():
+        assert not ln.lstrip().startswith("#"), f"YQL sample must not contain # lines: {ln!r}"
+        assert not ln.lstrip().startswith("//"), f"YQL sample must not contain // lines: {ln!r}"


### PR DESCRIPTION
This PR includes #264, so if we merge it, that one could be closed.

In addition to generating queries (and therefore judgments) from documents, we can now create those from "categories" - i.e., facet values. For example, movie genres or E-commerce product tags.

The category values could be provided manually in the config or derived from facet results (given a query template for the search engine).

## Config example
```
category_queries:
  # Explicit-values mode
  - fields: ["genres"]
    values: ["comedy", "action"]
    query_text_template_file: "templates/genre_query.tmpl"   # optional NL wrapper

  # Engine-discovery mode
  - fields: ["genres"]
    values_query_template_file: "templates/genre_facet_solr.json"
```

## High level implementation notes

- **`fetch_field_values` per engine,** — each matches its existing retrieval-template convention.

- **Each query is tagged with where it came from this run** — `user`, `category`, `llm`, or `cached` (loaded from a previous run's `datastore.json`).

- **Budget fix.** When the total number of queries exceeds `num_queries_needed`, the budget used to truncate by raw insertion order, which meant cached queries from `datastore.json` (loaded first) could push fresh user/category/LLM queries out of scoring. The budget now sorts by source priority first (`user`/`category` > `llm` > `cached`), so fresh queries always win their slot. The same priority is used when deciding whether to call the LLM at all — cached queries don't count toward the "do we still need more?" check.

- **`main()` phase split.** `generate_and_add_queries` now goes like `add_user_queries` / `add_category_queries` / `fetch_and_add_seed_documents` / `generate_and_add_queries_from_documents`.

## Gotchas

- **`generate_queries_from_documents` semantics changed.** Was `Optional[bool] = True` and unread by `main()`. Now `bool = True` and actually gates LLM generation + the seed-fetch decision. A YAML `null` in this field used to be silently equivalent to absent; it now raises a validation error.

- **Validator ordering matters.** Path-collision validators run before content-reading validators, so a swapped `values_query_template_file` / `query_text_template_file` produces "different concepts" rather than "missing placeholder". Don't reorder.

## Next steps (sometime 🙂 )

Multi-field category sources. `fields: List[str]` is already accepted in the schema; config currently rejects more than one entry with "not yet supported".
